### PR TITLE
prefer setuptools to distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@
 #   $ python setup.py install
 #
 
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 import os, sys
 
 VERSION = "1.2a3-20060212"


### PR DESCRIPTION
setuptools is able to more easily finds vcvarsal.bat.  vcvarsal.bat is required on some Windows systems to compile using Microsoft Visual C++.

This is what currently happens on my Windows box during installation:

```
C:\Users\mcochran\Downloads\aggdraw-master>python setup.py build_ext
=== freetype not available (edit setup.py to enable)
running build_ext
building 'aggdraw' extension
error: Unable to find vcvarsall.bat
```
