### PR TITLE
Fix freetype config check when quotes are included

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with the WCK renderer.
 try:
     # pointer to freetype build directory (tweak as necessary)
     FREETYPE_ROOT = subprocess.check_output(
-        ['freetype-config', '--prefix']).strip().decode()
+        ['freetype-config', '--prefix']).strip().replace('"', '').decode()
     print("=== freetype found: '{}'".format(FREETYPE_ROOT))
 except (OSError, subprocess.CalledProcessError):
     print("=== freetype not available")

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with the WCK renderer.
 try:
     # pointer to freetype build directory (tweak as necessary)
     FREETYPE_ROOT = subprocess.check_output(
-        ['freetype-config', '--prefix']).strip().replace('"', '').decode()
+        ['freetype-config', '--prefix']).strip().replace(b'"', b'').decode()
     print("=== freetype found: '{}'".format(FREETYPE_ROOT))
 except (OSError, subprocess.CalledProcessError):
     print("=== freetype not available")


### PR DESCRIPTION
Sometimes `freetype-config --prefix` includes quotes in its output:

```
(py27_dask_test) [goesdev1@cmc-goesr-dev1] !% freetype-config --prefix
"/usr"
```

This PR makes sure to remove the quotes so they don't affect the command line arguments passed to the compiler.