### PR TITLE
Fix travis tests with double brackets in if statements

### DIFF
--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ "${BUILDMODE}" = "ASTROPY" ]; then
+if [[ "${BUILDMODE}" == "ASTROPY" ]]; then
     git clone --depth 1 git://github.com/astropy/ci-helpers.git
     source ci-helpers/travis/setup_conda.sh
-elif [ "${BUILDMODE}" = "CIBUILDWHEEL" ]; then
+elif [[ "${BUILDMODE}" == "CIBUILDWHEEL" ]]; then
   export PIP=pip
-  if [ $(uname) = "Darwin" ]; then
+  if [[ $(uname) == "Darwin" ]]; then
     export PIP=pip2
   fi
   $PIP install cibuildwheel==0.10.0


### PR DESCRIPTION
Closes #51 

It seems pretty random when travis lets these tests pass so it may be something with incompatible bash usage for OSX.