### PR TITLE
Use array delete for point arrays

### DIFF
--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -1187,7 +1187,7 @@ draw_line(DrawObject* self, PyObject* args)
         path.move_to(xy[0].X, xy[0].Y);
         for (int i = 1; i < count; i++)
             path.line_to(xy[i].X, xy[i].Y);
-        delete xy;
+        delete [] xy;
         self->draw->draw(path, pen);
     }
 
@@ -1283,7 +1283,7 @@ draw_polygon(DrawObject* self, PyObject* args)
         for (int i = 1; i < count; i++)
             path.line_to(xy[i].X, xy[i].Y);
         path.close_polygon();
-        delete xy;
+        delete [] xy;
         self->draw->draw(path, pen, brush);
     }
 
@@ -1407,7 +1407,7 @@ draw_symbol(DrawObject* self, PyObject* args)
         self->draw->draw(p, pen, brush);
     }
 
-    delete xy;
+    delete [] xy;
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -2075,7 +2075,7 @@ path_new(PyObject* self_, PyObject* args)
         self->path->move_to(xy[0].X, xy[0].Y);
         for (int i = 1; i < count; i++)
             self->path->line_to(xy[i].X, xy[i].Y);
-        delete xy;
+        delete [] xy;
     }
 
     return (PyObject*) self;
@@ -2464,7 +2464,7 @@ path_polygon(PathObject* self, PyObject* args)
     for (int i = 1; i < count; i++)
         path.line_to(xy[i].X, xy[i].Y);
     path.close_polygon();
-    delete xy;
+    delete [] xy;
 
     self->path->add_path(path, 0, false);
 


### PR DESCRIPTION
This change uses array delete on PointF arrays allocated by getpoints in aggdraw.cxx.

While doing some testing on a local build made with address sanitizer, I got an error that the allocator and deallocator for points in draw_line didn't match. This looks true to me:

getpoints, returning memory allocated with new PointF[]:
https://github.com/pytroll/aggdraw/blob/66af911166df52d790f9ef863a4e7f02faf21244/aggdraw.cxx#L894

draw_line, calling getpoints and then releasing the PointF using simple delete:
https://github.com/pytroll/aggdraw/blob/66af911166df52d790f9ef863a4e7f02faf21244/aggdraw.cxx#L1190

SUMMARY: 

AddressSanitizer: alloc-dealloc-mismatch (/.../libtools_build_sanitizers_asan-ubsan-py.so+0xa06c0) in operator delete(void*, unsigned long)

==1481283==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x603000050f80
SCARINESS: 10 (alloc-dealloc-mismatch)
    #0 0x7ff93c34e6c0 in operator delete(void*, unsigned long) (/.../libtools_build_sanitizers_asan-ubsan-py.so+0xa06c0)
    #1 0x7ff92b4a7ba4 in draw_line(DrawObject*, _object*) /tmp/pip-wheel-2XAzmg/aggdraw/aggdraw.cxx:1190:16
    #2 0x7ff93bfaa2ee in call_function /.../Python-2.7.14/Python/ceval.c:4357:13

 0x603000050f80 is located 0 bytes inside of 24-byte region [0x603000050f80,0x603000050f98)
allocated by thread T0 here:
    #0 0x7ff93c34d450 in operator new[](unsigned long) (/.../libtools_build_sanitizers_asan-ubsan-py.so+0x9f450)
    #1 0x7ff92b4a4c9a in getpoints(_object*, int*) /tmp/pip-wheel-2XAzmg/aggdraw/aggdraw.cxx:894:24
    #2 0x7ff92b4a7aff in draw_line(DrawObject*, _object*) /tmp/pip-wheel-2XAzmg/aggdraw/aggdraw.cxx:1183:31
    #3 0x7ff93bfaa2ee in call_function /.../Python-2.7.14/Python/ceval.c:4357:13

Testing after this change, address sanitizer seems happy.
Thanks, maintainers!
