### PR TITLE
Change default linejoin and linecap to preserve previous behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - EVENT_TYPE='push pull_request'
   - SETUP_CMD='test'
   - CONDA_CHANNELS='conda-forge'
-  - CONDA_CHANNEL_PRIORITY='True'
+  - CONDA_CHANNEL_PRIORITY='strict'
   - CIBW_TEST_REQUIRES='numpy pillow pytest'
   - CIBW_TEST_COMMAND='python {project}/selftest.py'
   - CIBW_BEFORE_BUILD_LINUX='yum install -y freetype-devel'

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -1831,7 +1831,7 @@ pen_new(PyObject* self_, PyObject* args, PyObject* kw)
     PyObject* color;
     float width = 1.0;
     agg::line_join_e line_join = agg::miter_join;
-    agg::line_cap_e line_cap = agg::round_cap;
+    agg::line_cap_e line_cap = agg::butt_cap;
     float miter_limit = 4.0; // Like default in agg_math_stroke.h
     int opacity = 255;
     static const char* const kwlist[] = { "color", "width", "opacity", "linejoin", "linecap", "miterlimit", NULL };

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -1813,11 +1813,14 @@ const char *pen_doc = "Creates a Pen object.\n"
                       "    Pen width. Default 1.\n"
                       "opacity : int, optional\n"
                       "    Pen opacity. Default 255.\n"
-                      "linejoin : in, optional\n"
-                      "    Type of line_join. Default 2 (round join)\n"
-                      "linecap  : int, optional\n"
-                      "    Type of linecap. Default 2 (round cap).\n"
-                      "miterlimit  : float, optional\n"
+                      "linejoin : int, optional\n"
+                      "    Type of line_join. Types are 0=miter_join\n"
+                      "    1=miter_join_revert; 2=round_join; 3=bevel_join;\n"
+                      "    4=miter_join_round. Default 0 (miter join).\n"
+                      "linecap : int, optional\n"
+                      "    Type of linecap. Types are 0=butt_cap;\n"
+                      "    1=square_cap; 2=round_cap. Default 1 (butt cap).\n"
+                      "miterlimit : float, optional\n"
                       "    Type of miterlimit. Default 4.0.\n";
 
 static PyObject*
@@ -1827,7 +1830,7 @@ pen_new(PyObject* self_, PyObject* args, PyObject* kw)
 
     PyObject* color;
     float width = 1.0;
-    agg::line_join_e line_join = agg::round_join;
+    agg::line_join_e line_join = agg::miter_join;
     agg::line_cap_e line_cap = agg::round_cap;
     float miter_limit = 4.0; // Like default in agg_math_stroke.h
     int opacity = 255;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,8 +54,8 @@ build_script:
 
 
 test_script:
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda activate test
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda info --envs
+  - if [%CIBUILDWHEEL%]==[0] conda activate test
+  - if [%CIBUILDWHEEL%]==[0] conda info --envs
   - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% pip install -e .
   - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python selftest.py
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ build_script:
 
 
 test_script:
-  - if [%CIBUILDWHEEL%]==[0] conda activate test
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda activate test
   - if [%CIBUILDWHEEL%]==[0] conda info --envs
   - if [%CIBUILDWHEEL%]==[0] pip install -e .
   - if [%CIBUILDWHEEL%]==[0] python selftest.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,6 @@ environment:
 install:
   - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] powershell ci-helpers/appveyor/install-miniconda.ps1
-  - if [%CIBUILDWHEEL%]==[0] conda init bash cmd.exe powershell
   - if [%CIBUILDWHEEL%]==[0] conda activate test
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,12 +56,12 @@ build_script:
 
 test_script:
   - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda activate test
-  - if [%CIBUILDWHEEL%]==[0] conda info --envs
-  - if [%CIBUILDWHEEL%]==[0] pip install -e .
-  - if [%CIBUILDWHEEL%]==[0] python selftest.py
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda info --envs
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% pip install -e .
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python selftest.py
 
 after_test:
-  - if [%CIBUILDWHEEL%]==[0] python setup.py bdist_wheel bdist_wininst
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,10 +41,6 @@ environment:
       CIBUILDWHEEL: 0
 
 install:
-  #    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-  - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
-  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-  - "conda activate test"
 #  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] powershell ci-helpers/appveyor/install-miniconda.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,10 +41,14 @@ environment:
       CIBUILDWHEEL: 0
 
 install:
-  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  #    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+  - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
+  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+  - "conda activate test"
+#  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] powershell ci-helpers/appveyor/install-miniconda.ps1
-  - if [%CIBUILDWHEEL%]==[0] SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
-  - if [%CIBUILDWHEEL%]==[0] call activate test
+  - if [%CIBUILDWHEEL%]==[0] conda activate test
   
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,15 +55,5 @@ build_script:
 
 
 test_script:
-  - if [%CIBUILDWHEEL%]==[0] conda activate test
-  - if [%CIBUILDWHEEL%]==[0] conda info --envs
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% pip install -e .
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python selftest.py
-
-after_test:
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst
-  - ps: "ls dist"
-
-artifacts:
-  # Archive the generated wheel package in the ci.appveyor.com build report.
-  - path: dist\*
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda run -n test pip install -e .
+  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% conda run -n test python selftest.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
     CONDA_DEPENDENCIES: "sphinx pillow coveralls coverage pytest"
     CONDA_CHANNELS: "conda-forge"
-    CONDA_CHANNEL_PRIORITY: "True"
+    CONDA_CHANNEL_PRIORITY: "strict"
     TWINE_USERNAME: "dhoese"
     TWINE_PASSWORD:
       secure: zws6RrJGZ5XULrqXQDF/Cw==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,7 @@ environment:
       CIBUILDWHEEL: 0
 
 install:
-#  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
-  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
+  - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] powershell ci-helpers/appveyor/install-miniconda.ps1
   - if [%CIBUILDWHEEL%]==[0] conda activate test
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,9 @@ environment:
 install:
   - if [%CIBUILDWHEEL%]==[0] git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - if [%CIBUILDWHEEL%]==[0] powershell ci-helpers/appveyor/install-miniconda.ps1
+  - if [%CIBUILDWHEEL%]==[0] conda init bash cmd.exe powershell
   - if [%CIBUILDWHEEL%]==[0] conda activate test
-  
+
 build: false  # Not a C# project, build stuff at the test step instead.
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ build_script:
 
 
 test_script:
+  - if [%CIBUILDWHEEL%]==[0] conda activate test
   - if [%CIBUILDWHEEL%]==[0] conda info --envs
   - if [%CIBUILDWHEEL%]==[0] pip install -e .
   - if [%CIBUILDWHEEL%]==[0] python selftest.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,11 +56,11 @@ build_script:
 
 test_script:
   - if [%CIBUILDWHEEL%]==[0] conda info --envs
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% pip install -e .
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python selftest.py
+  - if [%CIBUILDWHEEL%]==[0] pip install -e .
+  - if [%CIBUILDWHEEL%]==[0] python selftest.py
 
 after_test:
-  - if [%CIBUILDWHEEL%]==[0] %CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst
+  - if [%CIBUILDWHEEL%]==[0] python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
 artifacts:

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ "${BUILDMODE}" == "ASTROPY" ]]; then
-#    git clone --depth 1 git://github.com/astropy/ci-helpers.git
-    git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
+    git clone --depth 1 git://github.com/astropy/ci-helpers.git
     source ci-helpers/travis/setup_conda.sh
 elif [[ "${BUILDMODE}" == "CIBUILDWHEEL" ]]; then
   export PIP=pip

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 if [[ "${BUILDMODE}" == "ASTROPY" ]]; then
-    git clone --depth 1 git://github.com/astropy/ci-helpers.git
+#    git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
     source ci-helpers/travis/setup_conda.sh
 elif [[ "${BUILDMODE}" == "CIBUILDWHEEL" ]]; then
   export PIP=pip

--- a/selftest.py
+++ b/selftest.py
@@ -103,7 +103,7 @@ def test_graphics2():
     canvas.symbol((0, 0), symbol, pen)
     canvas.flush()
     # This is different from agg 2.4 but fully acceptable!
-    assert np.asarray(image).sum() == 51368
+    assert np.asarray(image).sum() == 51200
 
 
 def test_graphics3():


### PR DESCRIPTION
Closes #61. This changes the default line join and cap types to miter and butt which preserves the previous Agg settings. @dov any idea/reason why these defaults were changed when switching to agg 2.4? Also, @a-hurst please review.

I got the mapping of the constants [here](https://github.com/tomhughes/agg/blob/0123842bf579f0a79c444b28abe2ecdd5463acfa/include/agg_math_stroke.h#L29-L44) since the main antigrain website seems broken. Using raw enum integers this way is not the most flexible or backwards compatible. However, mapping strings to the constants is not the most straight forward thing to do in C++ so I will wait until we migrate to cython to change this to accept ints (backwards compatible) or strings for the names of the join and cap types. I did realize that #3 was doing this string checking (FYI @ simonkolotov), but since it looks like the API in 2.4 changed quite a bit, I didn't really have time to adjust that PR to work for this. This at least preserves the current behavior.
