### PR TITLE
Also build wheels for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
   - os: linux
     env:
     - BUILDMODE=ASTROPY
-    - PYTHON_VERSION=3.7
+    - PYTHON_VERSION=3.8
   - os: osx
     env:
     - BUILDMODE=ASTROPY
@@ -32,7 +32,7 @@ matrix:
   - os: osx
     env:
     - BUILDMODE=ASTROPY
-    - PYTHON_VERSION=3.7
+    - PYTHON_VERSION=3.8
   - sudo: required
     language: python
     services:


### PR DESCRIPTION
Currently no wheels are created for python 3.8. This prs also creates these which removes the need to build them locally