### PR TITLE
Attempt to fix PyPy/CPython 3.8+ compatibility

### DIFF
--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -170,7 +170,11 @@ static PyTypeObject DrawType = {
     "Draw", sizeof(DrawObject), 0,
     /* methods */
     (destructor) draw_dealloc, /* tp_dealloc */
+#if PY_VERSION_HEX < 0x030800b4
     (printfunc)0, /* tp_print */
+#else
+    (Py_ssize_t)0, /* tp_vectorcall_offset */
+#endif
     (getattrfunc)draw_getattr, /* tp_getattr */
     0, /* tp_setattr */
 };
@@ -263,7 +267,11 @@ static PyTypeObject FontType = {
     "Font", sizeof(FontObject), 0,
     /* methods */
     (destructor) font_dealloc, /* tp_dealloc */
+#if PY_VERSION_HEX < 0x030800b4
     (printfunc)0, /* tp_print */
+#else
+    (Py_ssize_t)0, /* tp_vectorcall_offset */
+#endif
     0, /* tp_getattr */
     0, /* tp_setattr */
     0, /* tp_reserved */
@@ -304,7 +312,11 @@ static PyTypeObject PathType = {
     "Path", sizeof(PathObject), 0,
     /* methods */
     (destructor) path_dealloc, /* tp_dealloc */
+#if PY_VERSION_HEX < 0x030800b4
     (printfunc)0, /* tp_print */
+#else
+    (Py_ssize_t)0, /* tp_vectorcall_offset */
+#endif
     0, /* tp_getattr */
     0, /* tp_setattr */
     0, /* tp_reserved */


### PR DESCRIPTION
Conda-forge has been trying for a long time to build a PyPy binary of aggdraw, but has been failing:

https://github.com/conda-forge/aggdraw-feedstock/pull/25

The error is basically:

```
  aggdraw.cxx:271:1: error: invalid conversion from 'printfunc' {aka 'int (*)(_object*, FILE*, int)'} to 'Py_ssize_t' {aka 'long int'} [-fpermissive]
    271 | };
        | ^
        | |
        | printfunc {aka int (*)(_object*, FILE*, int)}
  aggdraw.cxx:312:1: error: invalid conversion from 'printfunc' {aka 'int (*)(_object*, FILE*, int)'} to 'Py_ssize_t' {aka 'long int'} [-fpermissive]
    312 | };
        | ^
        | |
        | printfunc {aka int (*)(_object*, FILE*, int)}
  error: command '/home/conda/feedstock_root/build_artifacts/aggdraw_1667346120715/_build_env/bin/x86_64-conda-linux-gnu-cc' failed with exit code 1

```

It turns out `printfunc` is deprecated and unused, but was repurposed in Python 3.8:

https://peps.python.org/pep-0590/#changes-to-the-pytypeobject-struct

I found a PR in swig that had to make the same type of update (https://github.com/swig/swig/pull/2264) so I copied that simple logic here. Once merged I'll have to cherry-pick it to the `maint` branch so it can be released for the current stable version.

I should be able to turn on PyPy wheel builds in CI too.