### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["packaging", "setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,10 @@ import os
 import sys
 import subprocess
 import platform
-from distutils.sysconfig import get_config_var
-from distutils.version import LooseVersion
+from sysconfig import get_config_var
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+from packaging.version import Version
+from setuptools import setup, Extension
 
 VERSION = "1.3.13"
 
@@ -48,9 +45,12 @@ def is_platform_mac():
 # MACOSX_DEPLOYMENT_TARGET before calling setup.py
 if is_platform_mac():
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
-        current_system = LooseVersion(platform.mac_ver()[0])
-        python_target = LooseVersion(get_config_var('MACOSX_DEPLOYMENT_TARGET'))
-        if python_target < '10.9' and current_system >= '10.9':
+        current_system = Version(platform.mac_ver()[0])
+        python_target = Version(get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if (
+            python_target < Version('10.9') and
+            current_system >= Version('10.9')
+        ):
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 


### PR DESCRIPTION
`setup.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) has no suggestions for `distutils.sysconfig`, but [`sysconfig`](https://docs.python.org/3/library/sysconfig.html) is a good alternative. It does suggest using [`packaging.version`](https://packaging.pypa.io/en/stable/version.html) instead of `distutils.version`.

Because `setup_requires` is deprecated, [PEP 517 (`pyproject.toml`)](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement) is used for the build time dependencies.