### PR TITLE
Drop 32-bit wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           CIBW_TEST_COMMAND: python {project}/selftest.py
           CIBW_BEFORE_BUILD_LINUX: yum install -y freetype-devel
-          CIBW_SKIP: pp* *-musllinux* cp36-*
+          CIBW_SKIP: "cp36-* pp* *-win32 *-manylinux_i686 *-musllinux*"
           CIBW_TEST_REQUIRES: numpy pillow pytest
           CIBW_ARCHS_LINUX: auto aarch64
           # disable finding unintended freetype installations


### PR DESCRIPTION
Numpy no longer provides 32-bit wheels and it just takes too long to try to build numpy on 32-bit wheels. If someone has a good alternative then let me know. Right now we don't even compile against numpy (that could easily change in the future), but one of our tests requires numpy. Since it isn't available pip tries to build it from source.