### PR TITLE
Remove incompatible "register" keyword from AGG source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # The aggdraw Library
 
+## Version 1.3.18
+
+- Remove "register" keyword from AGG C++ for compiler compatibility
+
+## Version 1.3.17
+
+- Fix Python 3.12 compatibility
+
 ## Version 1.3.16
 
 - Build changes to support for Python 3.12

--- a/agg2/include/agg_trans_affine.h
+++ b/agg2/include/agg_trans_affine.h
@@ -251,7 +251,7 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::transform(double* x, double* y) const
     {
-        register double tx = *x;
+        double tx = *x;
         *x = tx * m0 + *y * m2 + m4;
         *y = tx * m1 + *y * m3 + m5;
     }
@@ -259,9 +259,9 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::inverse_transform(double* x, double* y) const
     {
-        register double d = determinant();
-        register double a = (*x - m4) * d;
-        register double b = (*y - m5) * d;
+        double d = determinant();
+        double a = (*x - m4) * d;
+        double b = (*y - m5) * d;
         *x = a * m3 - b * m2;
         *y = b * m0 - a * m1;
     }

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from sysconfig import get_config_var
 from packaging.version import Version
 from setuptools import setup, Extension
 
-VERSION = "1.3.17"
+VERSION = "1.3.18"
 
 SUMMARY = "High quality drawing interface for PIL."
 


### PR DESCRIPTION
The "register" keyword in C++ is not supported in OSX compilers as seen in the conda-forge builds of this package:

https://github.com/conda-forge/aggdraw-feedstock/pull/30

Clang (or whatever compiler conda-forge is using) no longer warns about it but errors out. Both @mraspaud and I agree that our research says it isn't necessary and can be removed. It may hurt performance on some platforms, but for the sake of maintenance and seeing as future versions of the AGG library seemed to have removed it I think it is OK.

NOTE: I did not remove its usage in `agg2/src/platform/win32/agg_platform_support.cpp` as that was not detected or used in the OSX builds. That may need to be removed in the future if Windows compilers get more strict.