### PR TITLE
Adding back support for arm64 macOS wheels.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             pipx ensurepath
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_TEST_COMMAND: python {project}/selftest.py
           CIBW_BEFORE_BUILD_LINUX: yum install -y freetype-devel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           platforms: all
 
       # See discussion here: https://github.com/actions/runner-images/issues/9256
-      - name: Maker sure pipx is installed for the arm64 macOS runners.
+      - name: Make sure pipx is installed for the arm64 macOS runners.
         if: runner.os == 'macOS' && runner.arch == 'ARM64' 
         run: |
             brew install pipx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
           - os: windows-2019
             cibw_archs: "AMD64 ARM64"
           - os: macos-11
-            cibw_archs: "x86_64"  # arm64"  # No freetype on non-native platforms
+            cibw_archs: "x86_64"
+          - os: macos-14          # The macos-14 runner is arm64, while up until macos-13 the runners are x86_64.
+            cibw_archs: "arm64"
           - os: "ubuntu-20.04"
             cibw_archs: "aarch64"
           - os: "ubuntu-20.04"
@@ -53,6 +55,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      # See discussion here: https://github.com/actions/runner-images/issues/9256
+      - name: Maker sure pipx is installed for the arm64 macOS runners.
+        if: runner.os == 'macOS' && runner.arch == 'ARM64' 
+        run: |
+            brew install pipx
+            pipx ensurepath
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2


### PR DESCRIPTION
Hi,

Following our discussion in #92, I finally found time to look into and fix it.

Previously x86_64 macOS runners where used in trying to build both x86_64 and arm64 wheels. This produced working x86_64 wheels, but incomplete arm64 wheels (dependent libraries libreetype and libpng where not copied over since they were available only in the x86_64 version).

The problem is solved by building the arm64 wheels on an arm64 macOS runner.