### PR TITLE
Remove Mac x86 wheels, add Python 3.13 wheels, and fix documentation referring to deprecated tostring method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
         include:
           - os: windows-2019
             cibw_archs: "AMD64 ARM64"
+          - os: macos-13
+            cibw_archs: "x86_64"
           - os: macos-14          # The macos-14 runner is arm64, while up until macos-13 the runners are x86_64.
-            cibw_archs: "x86_64 arm64"
+            cibw_archs: "arm64"
           - os: "ubuntu-20.04"
             cibw_archs: "aarch64"
           - os: "ubuntu-20.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,8 @@ jobs:
         include:
           - os: windows-2019
             cibw_archs: "AMD64 ARM64"
-          - os: macos-11
-            cibw_archs: "x86_64"
           - os: macos-14          # The macos-14 runner is arm64, while up until macos-13 the runners are x86_64.
-            cibw_archs: "arm64"
+            cibw_archs: "x86_64 arm64"
           - os: "ubuntu-20.04"
             cibw_archs: "aarch64"
           - os: "ubuntu-20.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
           # disable finding unintended freetype installations
           CIBW_ENVIRONMENT_WINDOWS: "AGGDRAW_FREETYPE_ROOT=''"
           # we use libpng/libfreetype from homebrew which has a current limit of
-          # macos 12 (Monterey): https://formulae.brew.sh/formula/libomp
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12
+          # macos 14
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14
       - name: upload
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           # disable finding unintended freetype installations
           CIBW_ENVIRONMENT_WINDOWS: "AGGDRAW_FREETYPE_ROOT=''"
           # agg is not compatible with GCC 14+
-          CIBW_ENVIRONMENT_MACOS: CFLAGS='-fpermissive'
+          CIBW_ENVIRONMENT_MACOS: CXXFLAGS='-fpermissive'
       - name: upload
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           # disable finding unintended freetype installations
           CIBW_ENVIRONMENT_WINDOWS: "AGGDRAW_FREETYPE_ROOT=''"
+          # we use libpng/libfreetype from homebrew which has a current limit of
+          # macos 12 (Monterey): https://formulae.brew.sh/formula/libomp
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12
       - name: upload
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           # disable finding unintended freetype installations
           CIBW_ENVIRONMENT_WINDOWS: "AGGDRAW_FREETYPE_ROOT=''"
+          # agg is not compatible with GCC 14+
+          CIBW_ENVIRONMENT_MACOS: CFLAGS='-fpermissive'
       - name: upload
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             pipx ensurepath
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_TEST_COMMAND: python {project}/selftest.py
           CIBW_BEFORE_BUILD_LINUX: yum install -y freetype-devel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,6 @@ jobs:
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           # disable finding unintended freetype installations
           CIBW_ENVIRONMENT_WINDOWS: "AGGDRAW_FREETYPE_ROOT=''"
-          # agg is not compatible with GCC 14+
-          CIBW_ENVIRONMENT_MACOS: CXXFLAGS='-fpermissive'
       - name: upload
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yaml
           activate-environment: test-environment
+          mamba-version: "*"
+          channels: conda-forge
 
       - name: Run tests
         shell: bash -l {0}
@@ -38,8 +38,6 @@ jobs:
         include:
           - os: windows-2019
             cibw_archs: "AMD64 ARM64"
-          - os: macos-13
-            cibw_archs: "x86_64"
           - os: macos-14          # The macos-14 runner is arm64, while up until macos-13 the runners are x86_64.
             cibw_archs: "arm64"
           - os: "ubuntu-20.04"

--- a/README.rst
+++ b/README.rst
@@ -93,3 +93,14 @@ ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Additional Patches
+------------------
+
+The AGG C++ vendored source code in this repository is no longer compatible
+with some modern compilers and coding styles. The aggdraw project has had to
+apply additional patches over time to fix compatibility or to retain backwards
+compatibility with previous versions of AGG to get the same end result. Some
+patches may be documented in README files, but all future patches should appear
+in the `patches/` directory in the root of this repository and were applied with
+commands such as `patch -p0 patches/tags_pointer_type_fix.patch`.

--- a/agg2/font_freetype/agg_font_freetype.cpp
+++ b/agg2/font_freetype/agg_font_freetype.cpp
@@ -150,7 +150,7 @@ namespace agg
 
         FT_Vector*  point;
         FT_Vector*  limit;
-        unsigned char*       tags;
+        char*       tags;
 
         int   n;         // index of contour in outline
         int   first;     // index of first point in contour
@@ -171,7 +171,7 @@ namespace agg
             v_control = v_start;
 
             point = outline.points + first;
-            tags  = outline.tags  + first;
+            tags  = (char *)outline.tags  + first;
             tag   = FT_CURVE_TAG(tags[0]);
 
             // A contour cannot start with a cubic control point!

--- a/agg2/font_freetype/agg_font_freetype.cpp
+++ b/agg2/font_freetype/agg_font_freetype.cpp
@@ -150,7 +150,7 @@ namespace agg
 
         FT_Vector*  point;
         FT_Vector*  limit;
-        char*       tags;
+        unsigned char*       tags;
 
         int   n;         // index of contour in outline
         int   first;     // index of first point in contour

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -1549,7 +1549,7 @@ const char *draw_frombytes_doc = "Copies data from a string buffer to the drawin
                                  "Parameters\n"
                                  "----------\n"
                                  "data : bytes\n"
-                                 "    A string containing packed image data, compatible with PIL’s tostring method.\n";
+                                 "    A string containing packed image data, compatible with PIL’s tobytes method.\n";
 
 static PyObject*
 draw_frombytes(DrawObject* self, PyObject* args)
@@ -2587,7 +2587,7 @@ const char *mod_doc = "Python interface to the Anti-Grain Graphics Drawing libra
                       "    >>> p = aggdraw.Pen(\"black\", 0.5)\n"
                       "    >>> d.line((0, 0, 500, 500), p)\n"
                       "    >>> d.line((0, 500, 500, 0), p)\n"
-                      "    >>> s = d.tostring()\n";
+                      "    >>> s = d.tobytes()\n";
 
 #ifdef IS_PY3K
 static struct PyModuleDef moduledef = {

--- a/patches/tags_pointer_type_fix.patch
+++ b/patches/tags_pointer_type_fix.patch
@@ -1,11 +1,11 @@
 --- agg2/font_freetype/agg_font_freetype.cpp.orig	2024-03-06 10:16:58
-+++ agg2/font_freetype/agg_font_freetype.cpp	2024-09-11 09:17:23
-@@ -150,7 +150,7 @@
++++ agg2/font_freetype/agg_font_freetype.cpp	2024-09-10 21:13:37
+@@ -171,7 +171,7 @@
+             v_control = v_start;
  
-         FT_Vector*  point;
-         FT_Vector*  limit;
--        char*       tags;
-+        unsigned char*       tags;
+             point = outline.points + first;
+-            tags  = outline.tags  + first;
++            tags  = (char *)outline.tags  + first;
+             tag   = FT_CURVE_TAG(tags[0]);
  
-         int   n;         // index of contour in outline
-         int   first;     // index of first point in contour
+             // A contour cannot start with a cubic control point!

--- a/patches/tags_pointer_type_fix.patch
+++ b/patches/tags_pointer_type_fix.patch
@@ -1,0 +1,11 @@
+--- agg2/font_freetype/agg_font_freetype.cpp.orig	2024-03-06 10:16:58
++++ agg2/font_freetype/agg_font_freetype.cpp	2024-09-11 09:17:23
+@@ -150,7 +150,7 @@
+ 
+         FT_Vector*  point;
+         FT_Vector*  limit;
+-        char*       tags;
++        unsigned char*       tags;
+ 
+         int   n;         // index of contour in outline
+         int   first;     // index of first point in contour

--- a/setup.py
+++ b/setup.py
@@ -169,5 +169,4 @@ setup(
                   )
         ],
     python_requires='>=3.9',
-    tests_require=['pillow', 'pytest'],
     )

--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,6 @@ if FREETYPE_ROOT:
 if sys.platform == "win32":
     libraries.extend(["kernel32", "user32", "gdi32"])
 
-# agg C++ is not compatible with gcc 14
-extra_compile_args = ["-fpermissive", "-Wno-pointer-sign"]
-
 setup(
     name="aggdraw",
     version=VERSION,
@@ -169,7 +166,6 @@ setup(
                   define_macros=defines,
                   include_dirs=include_dirs,
                   library_dirs=library_dirs, libraries=libraries,
-                  extra_compile_args=extra_compile_args,
                   )
         ],
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ if sys.platform == "win32":
     libraries.extend(["kernel32", "user32", "gdi32"])
 
 # agg C++ is not compatible with gcc 14
-extra_compile_args = ["-fpermissive"]
+extra_compile_args = ["-fpermissive", "-Wno-pointer-sign"]
 
 setup(
     name="aggdraw",

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,9 @@ if FREETYPE_ROOT:
 if sys.platform == "win32":
     libraries.extend(["kernel32", "user32", "gdi32"])
 
+# agg C++ is not compatible with gcc 14
+extra_compile_args = ["-fpermissive"]
+
 setup(
     name="aggdraw",
     version=VERSION,
@@ -165,7 +168,8 @@ setup(
         Extension("aggdraw", ["aggdraw.cxx"] + sources,
                   define_macros=defines,
                   include_dirs=include_dirs,
-                  library_dirs=library_dirs, libraries=libraries
+                  library_dirs=library_dirs, libraries=libraries,
+                  extra_compile_args=extra_compile_args,
                   )
         ],
     python_requires='>=3.9',


### PR DESCRIPTION
Closes #99.