### PR TITLE
Add initial free-threading support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,27 +31,37 @@ Build instructions (all platforms)
    To enable freetype, you need to build the library somewhere and
    make sure the `freetype-config` command is available on your PATH. The
    setup.py file will call `freetype-config --prefix` to locate
-   all of the necessary libraries and headers.
+   all of the necessary libraries and headers as part of installation.
 
-3. Build.
+3. Build and Install
 
-   The library uses a standard setup.py file, and you can use all
-   standard setup.py commands.   I recommend the following steps::
+   The library uses a standard setup.py file. Install the library
+   using ``pip`` from the root of the aggdraw repository::
 
-        $ python setup.py build_ext -i
+        $ python -m pip3 install .
+
+   Alternatively, it is possible to install the library in an "editable"
+   manner where the python environment will point to the local development
+   aggdraw directory.
+
+   ::
+
+        $ python -m pip3 install -e .
+
+   However, since aggdraw depends on compiling extension code, it must be
+   re-installed to re-build the extension.
+
+4. Once aggdraw is installed run the tests::
+
         $ python selftest.py
 
-   (if you're lazy, you can skip the above and just install the
-   library; setup.py will make sure the right stuff is built before
-   it's installed).
-
-4. Install.
-
-   If the selftest succeeds, you can install the library::
-
-        $ python setup.py install
-
 5. Enjoy!
+
+Free-threading support
+----------------------
+
+See the documentation site for current information for free-threading
+support: https://aggdraw.readthedocs.io/en/stable/
 
 AGG2 License
 ------------

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -2694,6 +2694,11 @@ aggdraw_init(void)
         );
 
     aggdraw_getcolor_obj = PyDict_GetItemString(g, "getcolor");
+
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
     return module;
 }
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,7 @@ of date with the current version of the library. Original examples will be
 migrated as time is available (pull requests welcome).
 
 Installation
-============
+------------
 
 Aggdraw is available on Linux, OSX, and Windows. It can be installed from PyPI
 with pip:
@@ -30,8 +30,25 @@ Or from conda with the conda-forge channel:
 
     conda install -c conda-forge aggdraw
 
+Free-threading support
+----------------------
+
+Basic free-threading compatibility has been enabled starting with the Python
+3.14 wheels of aggdraw 1.4.0. However, only the minimum steps have been taken
+to let Python 3.14's free-threaded build know that aggdraw could be used
+without the GIL. No additional locking or redesign of the library has been
+done.
+
+Aggdraw itself should have no global state, but each individual object is free
+to have internal state. It is up to the user to limit interactions for an
+aggdraw object to a single thread or to protect against concurrent access
+using locks. Even with this in mind, free-threading support in aggdraw is
+extremely unstable and experimental. If you have a use case for aggdraw
+in a free-threading environment please file an issue on GitHub to describe
+your use case and how it is going.
+
 API
-===
+---
 
 .. automodule:: aggdraw
     :members:
@@ -40,7 +57,7 @@ API
 
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ setup(
         "Development Status :: 4 - Beta",
         # "Development Status :: 5 - Production/Stable",
         "Topic :: Multimedia :: Graphics",
+        "Programming Language :: Python :: Free Threading :: 1 - Unstable",
         ],
     description=SUMMARY,
     download_url="http://www.effbot.org/downloads#aggdraw",


### PR DESCRIPTION
This PR does the bare minimum to enable Python's free-threading builds to use aggdraw without the GIL. I include documentation for how careful users should be while trying to do so.

Let's see what breaks...