### PR TITLE
Fix draw.path and improve documentation

### DIFF
--- a/aggdraw/core.py
+++ b/aggdraw/core.py
@@ -285,15 +285,18 @@ class Draw():
             pen = pen._pen
         self._draw.line(xy, pen)
 
-    def path(self, xy, path, pen=None, brush=None):
-        """Draws a path at the given positions.
+    def path(self, path, pen=None, brush=None):
+        """Draws a path to the surface.
         
         If a brush is given, it is used to fill the path. If a pen is given,
         it is used to draw an outline around the path. Either one (or both)
         can be left out.
 
-        Args:
-            xy: A Python sequence in the format (x, y, x, y, ...)
+        This method draws the path without translation (using the coordinates specified
+        when defining the :obj:`aggdraw.Path`). To draw a path at a specific location on
+        the surface, see :meth:`~aggdraw.Draw.symbol`.
+
+        Args
             path (:obj:`aggdraw.Path`): The Path object to draw.
             pen (:obj:`aggdraw.Pen`, optional): A pen to use for drawing an outline
                 around the path.
@@ -302,7 +305,7 @@ class Draw():
         
         """
         brush, pen = self._parse_args(brush, pen)
-        self._draw.path(xy, path._path, brush, pen)
+        self._draw.path(path._path, brush, pen)
 
     def pieslice(self, xy, start, end, pen=None, brush=None):
         """Draws a pie slice.
@@ -419,9 +422,12 @@ class Draw():
         it is used to draw an outline around the symbol. Either one (or both)
         can be left out.
 
+        This method can be used to draw both :obj:`aggdraw.Symbol` or
+        :obj:`aggdraw.Path` objects.
+
         Args:
             xy: A Python sequence in the format (x, y, x, y, ...)
-            symbol (:obj:`aggdraw.Symbol`): The Symbol object to draw.
+            symbol (:obj:`aggdraw.Symbol`): The Symbol (or Path) object to draw.
             pen (:obj:`aggdraw.Pen`, optional): A pen to use for drawing an outline
                 around the symbol.
             brush (:obj:`aggdraw.Brush`, optional): A brush to use for filling

--- a/aggdraw/core.py
+++ b/aggdraw/core.py
@@ -296,7 +296,7 @@ class Draw():
         when defining the :obj:`aggdraw.Path`). To draw a path at a specific location on
         the surface, see :meth:`~aggdraw.Draw.symbol`.
 
-        Args
+        Args:
             path (:obj:`aggdraw.Path`): The Path object to draw.
             pen (:obj:`aggdraw.Pen`, optional): A pen to use for drawing an outline
                 around the path.

--- a/aggdraw/tests/test_aggdraw.py
+++ b/aggdraw/tests/test_aggdraw.py
@@ -130,7 +130,7 @@ def test_path():
     draw.line(p)
     draw.polygon(p)
     draw.symbol((0, 0), p)
-
+    draw.path(p)
 
 def test_symbol():
     from aggdraw import Symbol

--- a/aggdraw/tests/test_aggdraw.py
+++ b/aggdraw/tests/test_aggdraw.py
@@ -132,6 +132,7 @@ def test_path():
     draw.symbol((0, 0), p)
     draw.path(p)
 
+
 def test_symbol():
     from aggdraw import Symbol
     Symbol("M0,0L0,0L0,0L0,0Z")


### PR DESCRIPTION
Fixes a bug with the pure Python wrapper (and documentation), where `Draw.path` was documented in the original effbot docs (and thus implemented in the wrapper) as having both an `xy` parameter and a `path` parameter, just like `Draw.symbol`. However, this is no longer the case as of this patch 11 years ago (https://github.com/pytroll/aggdraw/commit/c7cac6c9d88c0b7d85b1a6db6aa143c8be315cfd), which separated the `path` and `symbol` methods and removed the xy parameter from the `path` method, which effectively broke the `path` method wrapper.

This PR fixes the issue as well as cleans up the docs around `Draw.path` and `Draw.symbol` for a bit more clarity (and adds a unit test for `Draw.path`).