### PR TITLE
Modernize C++ code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,18 @@ aggdraw/__init__.py       re-exports Draw, Pen, Brush, Path, Symbol, Font + VERS
   - The `Pen_Check` / `Brush_Check` / `Font_Check` / `Path_Check` macros use `PyObject_TypeCheck`,
     not an identity test, because `Py_TPFLAGS_BASETYPE` is set. An identity test would make
     `draw_adaptor::draw` silently ignore a subclass.
-- **`Symbol` is still a module-level factory function**, and is the only one left. It returns a
-  `Path` — `Symbol` and `Path` have always been the same C type — which is why `core.Symbol`
-  stores its handle as `self._path` rather than `self._symbol`.
+- **`Symbol` is a subclass of `Path`**, at both layers. The C module exposes no functions at
+  all now — `moduledef.m_methods` is `NULL`. Because a spec's `Py_tp_base` slot cannot name a
+  type that does not exist until `aggdraw_init` runs, `Symbol` is built with
+  `PyType_FromSpecWithBases`, so the `types[]` registration table carries a `base` column and
+  **the `Symbol` row must come after the `Path` row**. `symbol_spec` defines only `tp_new` and
+  `tp_doc` — `tp_doc` is not inherited, and giving it `tp_methods` would build a second
+  descriptor set bound to `SymbolType`, making `Symbol.lineto()` reject a plain `Path`.
+  `Path.from_svg()` (`METH_VARARGS | METH_CLASS`) and `Symbol.__new__` both call one shared
+  parser, `path_from_svg_impl`, which allocates from the type it is handed.
+- **`Draw.symbol()` and `Draw.path()` both type-check against `PathType`**, so each accepts a
+  `Path` or a `Symbol`. Do not narrow `Draw.symbol()` to `SymbolType` — passing a plain `Path`
+  to it is documented, tested behaviour.
 - `aggdraw/core.py` is a recent addition. Each wrapper class holds a handle to the C object
   (`self._pen`, `self._brush`, `self._font`, `self._path`, `self._draw`) and forwards calls.
   Its purpose is documentation, IDE discoverability, and a place to put Python-side niceties.
@@ -141,6 +150,13 @@ decision, and do not document them wrongly.
   three distinct points deletes it** — it encloses no area, and AGG strokes closed paths as
   polygon outlines, so nothing is drawn. `Path([100,100, 400,100]).close()` renders nothing.
   `coords()` is identical before and after `close()`, so this is only observable in pixels.
+- **`Symbol` is deprecated** in favour of `Path.from_svg()`, and constructing one emits a
+  **`UserWarning`** — deliberately not a `DeprecationWarning`, which is ignored by default
+  outside `__main__`. The warning lives in `core.Symbol.__new__`, not `__init__`, so that the
+  inherited `Path.from_svg` (which calls `cls.__new__` and skips `__init__`) warns too. The C
+  layer never warns: `_aggdraw` is not public API, and `PyErr_WarnEx` has no `stack_level` that
+  is correct for both entry points. See
+  [pytroll/aggdraw#145](https://github.com/pytroll/aggdraw/issues/145).
 - **`Draw('BGRA', ...)` reports `.mode == 'RGBA'`.** Anything that round-trips through
   `Image.frombytes(draw.mode, draw.size, draw.tobytes())` will get the channel order wrong for
   BGRA surfaces.
@@ -167,6 +183,10 @@ decision, and do not document them wrongly.
 - Assert `!= WHITE` rather than an exact ink color when a shape is drawn with a `Pen` on integer
   coordinates — the pen straddles the path, so edges come out antialiased gray. Exact-color
   assertions are for half-pixel coordinates (`x.5`) or brush fills.
+- A deprecation warning inside a tight `sys.getallocatedblocks()` loop inflates the
+  measurement (~8000 blocks per 2200 warns) whenever the active filter is `always` — which
+  `-W always` sets, and which pytest 8 and older set for every test. Allocation-measuring tests
+  must call non-deprecated APIs; see `test_from_svg_error_paths_do_not_leak`.
 - Prefer asserting pixels over merely calling the API. Several existing tests are pure smoke
   tests with no assertions; don't add more.
 
@@ -180,7 +200,6 @@ decision, and do not document them wrongly.
 2. Add a `## Version X.Y.Z` section at the top of `CHANGELOG.md`.
 3. Tag `vX.Y.Z` and push; the `publish` CI job uploads to PyPI.
 
-Note that `doc/source/conf.py` hardcodes `version`/`release` separately and is currently stale.
 
 ## House rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,18 @@ aggdraw/__init__.py       re-exports Draw, Pen, Brush, Path, Symbol, Font + VERS
 ```
 
 - `aggdraw/_aggdraw.cxx` (~2500 lines) uses the low-level Python C API. `Pen`, `Brush`, `Font`,
-  `Symbol`, `Path`, and `Draw` are exposed as module-level **factory functions**, not heap
-  types — there is no `tp_new` and no subclassing.
+  `Path`, and `Draw` are **heap types**, built with `PyType_FromSpec` in `aggdraw_init` and
+  exposed on the module as real, subclassable classes. Each type's `PyType_Spec` sits next to
+  that type's own methods. Two consequences to respect:
+  - The deallocators must go through `tp_free` and then `Py_DECREF(Py_TYPE(self))`. Never call
+    `PyObject_DEL` on one of these objects, and never call a `*_dealloc` directly — use
+    `Py_DECREF`.
+  - The `Pen_Check` / `Brush_Check` / `Font_Check` / `Path_Check` macros use `PyObject_TypeCheck`,
+    not an identity test, because `Py_TPFLAGS_BASETYPE` is set. An identity test would make
+    `draw_adaptor::draw` silently ignore a subclass.
+- **`Symbol` is still a module-level factory function**, and is the only one left. It returns a
+  `Path` — `Symbol` and `Path` have always been the same C type — which is why `core.Symbol`
+  stores its handle as `self._path` rather than `self._symbol`.
 - `aggdraw/core.py` is a recent addition. Each wrapper class holds a handle to the C object
   (`self._pen`, `self._brush`, `self._font`, `self._path`, `self._draw`) and forwards calls.
   Its purpose is documentation, IDE discoverability, and a place to put Python-side niceties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@
   the PIL image; the reference is now taken at the point of assignment.
 - The dictionary backing the internal color-resolution helper is no longer
   leaked at import.
+- `Pen`, `Brush`, `Font`, `Path` and `Draw` in the C extension are now real
+  classes rather than factory functions returning opaque objects. They are
+  heap types built with `PyType_FromSpec`, exposed on `aggdraw._aggdraw` as
+  types, and can be subclassed. `Symbol` remains a factory function because it
+  returns a `Path`.
+- New: `Pen.color`, `Pen.width` and `Brush.color` report the resolved color and
+  width. The color is given as `(R, G, B, A)` after parsing, so an unrecognized
+  color reads back as black.
+- New: `Font.family`, `Font.style`, `Font.ascent` and `Font.descent` are now
+  available on the documented `aggdraw.Font` wrapper, not only on the
+  underlying C object.
 
 ## Version 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@
   black; `Pen(b"black")` is unchanged only by coincidence.
 - Setting an attribute on a `Pen` or `Brush` now raises `AttributeError` rather
   than `TypeError`, a side effect of the types being readied properly.
+- Fix a memory leak in `Path.coords()`, which leaked one float object per
+  coordinate on every call. `PyList_Append` takes its own reference, so the one
+  returned by `PyFloat_FromDouble` was never released.
+- Fix a memory leak of the `agg::trans_affine` set by `Draw.settransform()`.
+  The transform was freed when replaced but never when the `Draw` itself was
+  deallocated.
+- Fix memory leaks on several constructor error paths, previously marked
+  `FIXME`. A rejected `Symbol()` path descriptor, a `Font()` whose file cannot
+  be loaded, and a `Draw()` whose image data is the wrong size all leaked the
+  half-built object.
+- Fix a window in `Draw(image)` where the object held a borrowed reference to
+  the PIL image; the reference is now taken at the point of assignment.
+- The dictionary backing the internal color-resolution helper is no longer
+  leaked at import.
 
 ## Version 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 - Fix incorrect and missing docstrings in the C extension (`help()` output)
 - Declare Pillow as a runtime dependency (`install_requires`)
+- Remove all Python 2 support code from the C extension. The minimum supported
+  Python has been 3.11 since 1.4.0, so every `#ifdef IS_PY3K` fallback was dead
+  code.
+- Fix a segfault in `type()` on any `aggdraw._aggdraw` object. The type objects
+  were never passed to `PyType_Ready`, so they kept a NULL `ob_type`.
+- Fix a segfault when a color is a non-ASCII string, e.g. `Pen("café")`. Such a
+  color is now treated as unrecognized (black), like any other one aggdraw and
+  Pillow cannot resolve.
+- **Breaking:** `Font.family` and `Font.style` now return `str` instead of
+  `bytes`. These are only reachable on the underlying `aggdraw._aggdraw.Font`
+  object, not through the documented `aggdraw.Font` wrapper.
+- **Breaking:** `bytes` are no longer accepted where a `str` is expected -- as a
+  color, as text to draw, or as a PIL image's `mode`. `Pen(b"#ff0000")` used to
+  render red and now renders black, since an unrecognized color silently becomes
+  black; `Pen(b"black")` is unchanged only by coincidence.
+- Setting an attribute on a `Pen` or `Brush` now raises `AttributeError` rather
+  than `TypeError`, a side effect of the types being readied properly.
 
 ## Version 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,25 @@
   the PIL image; the reference is now taken at the point of assignment.
 - The dictionary backing the internal color-resolution helper is no longer
   leaked at import.
-- `Pen`, `Brush`, `Font`, `Path` and `Draw` in the C extension are now real
-  classes rather than factory functions returning opaque objects. They are
+- `Pen`, `Brush`, `Font`, `Path`, `Symbol` and `Draw` in the C extension are now
+  real classes rather than factory functions returning opaque objects. They are
   heap types built with `PyType_FromSpec`, exposed on `aggdraw._aggdraw` as
-  types, and can be subclassed. `Symbol` remains a factory function because it
-  returns a `Path`.
+  types, and can be subclassed. `aggdraw._aggdraw` no longer exposes any
+  module-level functions.
+- New: `Path.from_svg(path, scale=1.0)` builds a path from an SVG-style path
+  descriptor. This is the canonical replacement for `Symbol`. It is a
+  classmethod, so calling it on a subclass returns an instance of that subclass.
+- **Deprecated:** `aggdraw.Symbol`. Constructing one now emits a `UserWarning`;
+  use `aggdraw.Path.from_svg()` instead. `UserWarning` rather than
+  `DeprecationWarning` so that it is visible by default. See
+  [#145](https://github.com/pytroll/aggdraw/issues/145).
+- **Breaking:** `Symbol` is now a subclass of `Path` in both the Python wrapper
+  and the C extension, rather than a factory function that returned a `Path`.
+  `isinstance(Symbol(...), Path)` is now `True`; a `Symbol` has all the `Path`
+  methods (`lineto`, `coords`, ...), where previously it had none; `Draw.line`
+  and `Draw.polygon` now accept a `Symbol`, having rejected it with a
+  `TypeError` from their `isinstance` guard; and `type()` of the underlying
+  `aggdraw._aggdraw.Symbol` object is now `Symbol` rather than `Path`.
 - New: `Pen.color`, `Pen.width` and `Brush.color` report the resolved color and
   width. The color is given as `(R, G, B, A)` after parsing, so an unrecognized
   color reads back as black.

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -317,6 +317,7 @@ public:
         int index = 0;
 
         while (text_getchar(text, index, &ch)) {
+            index++;
             const agg::glyph_cache* glyph;
             glyph = font_manager.glyph(ch);
             if (!glyph)
@@ -340,7 +341,6 @@ public:
             }
             x += glyph->advance_x;
             y += glyph->advance_y;
-            index++;
         }
     }
 #endif

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -117,14 +117,16 @@ typedef struct {
 /* glue functions (see the init function for details) */
 static PyObject* aggdraw_getcolor_obj;
 
-/* All five types are heap types, created with PyType_FromSpec in aggdraw_init
+/* All six types are heap types, created with PyType_FromSpec in aggdraw_init
    and exposed on the module as real classes. Each PyType_Spec is defined next
-   to that type's own methods, further down the file. */
+   to that type's own methods, further down the file. Symbol is a subclass of
+   Path, so it is built with PyType_FromSpecWithBases instead. */
 static PyTypeObject* DrawType;
 static PyTypeObject* PenType;
 static PyTypeObject* BrushType;
 static PyTypeObject* FontType;
 static PyTypeObject* PathType;
+static PyTypeObject* SymbolType;
 
 /* The _Check macros use PyObject_TypeCheck rather than an identity test: the
    types set Py_TPFLAGS_BASETYPE, and an identity test would make
@@ -1129,7 +1131,8 @@ const char *draw_path_doc = "Draw the given path.\n"
                             "Parameters\n"
                             "----------\n"
                             "path : Path\n"
-                            "    Path object created by the `Path` factory.\n"
+                            "    The path to draw. A `Symbol` is a `Path`, so either is\n"
+                            "    accepted.\n"
                             "brush : Brush, optional\n"
                             "    Optional brush object created by the `Brush` factory.\n"
                             "pen : Pen, optional\n"
@@ -1168,8 +1171,9 @@ const char *draw_symbol_doc = "Draw a symbol at the given positions (experimenta
                               "----------\n"
                               "xy : iterable\n"
                               "    A Python sequence (x, y, x, y, …).\n"
-                              "symbol : Symbol\n"
-                              "    Symbol object created by the `Symbol` factory.\n"
+                              "symbol : Path\n"
+                              "    The path to stamp at each position. Any `Path` works; a\n"
+                              "    `Symbol` is a `Path`, so either is accepted.\n"
                               "brush : Brush, optional\n"
                               "    Optional brush object created by the `Brush` factory.\n"
                               "pen : Pen, optional\n"
@@ -1868,7 +1872,7 @@ font_dealloc(FontObject* self)
 
 /* -------------------------------------------------------------------- */
 
-const char *path_doc = "Path factory (experimental).\n"
+const char *path_doc = "Create a Path object (experimental).\n"
                        "\n"
                        "Parameters\n"
                        "----------\n"
@@ -1912,29 +1916,16 @@ path_new(PyTypeObject* type, PyObject* args, PyObject* kw)
     return (PyObject*) self;
 }
 
-const char *symbol_doc = "Create a Symbol object for use with :meth:`Draw.symbol`.\n"
-                         "\n"
-                         "Parameters\n"
-                         "----------\n"
-                         "path : str\n"
-                         "    An SVG-style path descriptor. The following operators\n"
-                         "    are supported: M (move), L (line), H (horizontal line), V (vertical line),\n"
-                         "    C (cubic bezier), S (smooth cubic bezier), Q (quadratic bezier),\n"
-                         "    T (smooth quadratic bezier), and Z (close path). Use lower-case\n"
-                         "    operators for relative coordinates, upper-case for absolute coordinates.\n"
-                         "scale : float, optional\n"
-                         "    A multiplier applied to every coordinate in the path descriptor\n"
-                         "    as it is parsed. Default 1.0.\n";
+/* Defined below, with the rest of the Path helpers. */
+void expandPaths(PathObject* self);
 
+/* The SVG-descriptor parser shared by Path.from_svg() and Symbol(). `type` is
+   PathType, SymbolType, or a Python subclass of either; allocating through
+   type->tp_alloc gives the caller an instance of the class it asked for. */
 static PyObject*
-symbol_new(PyObject* self_, PyObject* args)
+path_from_svg_impl(PyTypeObject* type, char* path, float scale)
 {
-    char* path;
-    float scale = 1.0;
-    if (!PyArg_ParseTuple(args, "s|f:Symbol", &path, &scale))
-        return NULL;
-
-    PathObject* self = (PathObject*) PathType->tp_alloc(PathType, 0);
+    PathObject* self = (PathObject*) type->tp_alloc(type, 0);
 
     if (self == NULL)
         return NULL;
@@ -2100,16 +2091,46 @@ symbol_new(PyObject* self_, PyObject* args)
         }
     }
 
-    if (curve) {
-        /* expand curves */
-        agg::path_storage* path = self->path;
-        agg::conv_curve<agg::path_storage> curve(*path);
-        self->path = new agg::path_storage();
-        self->path->add_path(curve, 0, false);
-        delete path;
-    }
+    if (curve)
+        expandPaths(self);
 
     return (PyObject*) self;
+}
+
+const char *path_from_svg_doc = "Create a path from an SVG-style path descriptor.\n"
+                                "\n"
+                                "This is a classmethod, so calling it on a subclass returns an\n"
+                                "instance of that subclass. It builds the object directly and does\n"
+                                "not go through the class's own constructor.\n"
+                                "\n"
+                                "Parameters\n"
+                                "----------\n"
+                                "path : str\n"
+                                "    An SVG-style path descriptor. The following operators\n"
+                                "    are supported: M (move), L (line), H (horizontal line), V (vertical line),\n"
+                                "    C (cubic bezier), S (smooth cubic bezier), Q (quadratic bezier),\n"
+                                "    T (smooth quadratic bezier), and Z (close path). Use lower-case\n"
+                                "    operators for relative coordinates, upper-case for absolute coordinates.\n"
+                                "scale : float, optional\n"
+                                "    A multiplier applied to every coordinate in the path descriptor\n"
+                                "    as it is parsed. Default 1.0.\n"
+                                "\n"
+                                "Returns\n"
+                                "-------\n"
+                                "Path\n"
+                                "    A new instance of the class this was called on.\n";
+
+static PyObject*
+path_from_svg(PyObject* cls, PyObject* args)
+{
+    char* path;
+    float scale = 1.0;
+    if (!PyArg_ParseTuple(args, "s|f:from_svg", &path, &scale))
+        return NULL;
+
+    /* The classmethod descriptor has already checked that cls is a subtype of
+       Path, so path_from_svg_impl can allocate from it unconditionally. */
+    return path_from_svg_impl((PyTypeObject*) cls, path, scale);
 }
 
 void expandPaths(PathObject *self)
@@ -2380,6 +2401,9 @@ path_dealloc(PathObject* self)
 
 static PyMethodDef path_methods[] = {
 
+    {"from_svg", (PyCFunction) path_from_svg,
+     METH_VARARGS | METH_CLASS, path_from_svg_doc},
+
     {"lineto", (PyCFunction) path_lineto, METH_VARARGS, path_lineto_doc},
     {"rlineto", (PyCFunction) path_rlineto, METH_VARARGS, path_rlineto_doc},
     {"curveto", (PyCFunction) path_curveto, METH_VARARGS, path_curveto_doc},
@@ -2414,13 +2438,62 @@ static PyType_Spec path_spec = {
 
 /* -------------------------------------------------------------------- */
 
-/* Pen, Brush, Font, Path and Draw are types, added to the module in
-   aggdraw_init. Symbol stays a factory function because it returns a Path --
-   Symbol and Path have always been the same C type. */
-static PyMethodDef aggdraw_functions[] = {
-    {"Symbol", (PyCFunction) symbol_new, METH_VARARGS, symbol_doc},
-    {NULL, NULL}
+const char *symbol_doc = "Deprecated alias for :meth:`Path.from_svg`.\n"
+                         "\n"
+                         "A Symbol is a Path built from an SVG-style path descriptor rather\n"
+                         "than from a coordinate sequence. It adds no state and no methods of\n"
+                         "its own; use Path.from_svg(path, scale) instead. The documented\n"
+                         "aggdraw.Symbol wrapper warns when one is constructed.\n"
+                         "\n"
+                         "Parameters\n"
+                         "----------\n"
+                         "path : str\n"
+                         "    An SVG-style path descriptor; see Path.from_svg for the\n"
+                         "    supported operators.\n"
+                         "scale : float, optional\n"
+                         "    A multiplier applied to every coordinate in the path descriptor\n"
+                         "    as it is parsed. Default 1.0.\n";
+
+static PyObject*
+symbol_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+    /* tp_new is handed keywords whether or not it wants them. The old
+       METH_VARARGS entry point rejected them for free; keep doing so rather
+       than silently ignoring Symbol("M0,0", scale=2). */
+    if (kw != NULL && PyDict_GET_SIZE(kw) != 0) {
+        PyErr_SetString(PyExc_TypeError, "Symbol() takes no keyword arguments");
+        return NULL;
+    }
+
+    char* path;
+    float scale = 1.0;
+    if (!PyArg_ParseTuple(args, "s|f:Symbol", &path, &scale))
+        return NULL;
+
+    return path_from_svg_impl(type, path, scale);
+}
+
+/* tp_dealloc, tp_methods, tp_alloc and tp_free are all inherited from Path.
+   path_dealloc reads Py_TYPE(self) rather than a hardcoded type, so it is
+   already correct for a subtype, and Symbol adds no fields to PathObject --
+   hence the basicsize below. Do not add tp_methods here: that would build a
+   second set of descriptors bound to SymbolType, and Symbol.lineto() would
+   then reject a plain Path. tp_doc is not inherited, so it must be given. */
+static PyType_Slot symbol_slots[] = {
+    {Py_tp_new, (void*) symbol_new},
+    {Py_tp_doc, DOC_SLOT(symbol_doc)},
+    {0, NULL}
 };
+
+static PyType_Spec symbol_spec = {
+    "aggdraw._aggdraw.Symbol",
+    sizeof(PathObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    symbol_slots
+};
+
+/* -------------------------------------------------------------------- */
 
 const char *mod_doc = "Python interface to the Anti-Grain Graphics Drawing library\n"
                       "\n"
@@ -2451,7 +2524,7 @@ static struct PyModuleDef moduledef = {
         "_aggdraw",
         mod_doc,
         -1,
-        aggdraw_functions,
+        NULL,       /* m_methods: every name in this module is a type */
         NULL,
         NULL,
         NULL,
@@ -2466,25 +2539,44 @@ aggdraw_init(void)
     if (module == NULL)
         return NULL;
 
-    /* Build the five types from their specs and expose them as real classes.
+    /* Build the six types from their specs and expose them as real classes.
        PyType_FromSpec fills in ob_type, so type() and help() work; each spec
        names its own tp_new, so the types are directly constructible and
        Py_TPFLAGS_BASETYPE lets them be subclassed. The deallocators go through
-       tp_free and drop a reference on the type, as heap types require. */
+       tp_free and drop a reference on the type, as heap types require.
+
+       A row naming a base gets it through PyType_FromSpecWithBases rather than
+       a Py_tp_base slot, because the base is itself a heap type that does not
+       exist until this loop creates it -- a static slot array cannot name it.
+       PyType_FromSpecWithBases(spec, NULL) is exactly PyType_FromSpec(spec),
+       so the rows without a base are unaffected. */
     static const struct {
         PyType_Spec* spec;
         PyTypeObject** slot;
         const char* name;
+        PyTypeObject** base;    /* NULL for a direct subclass of object */
     } types[] = {
-        {&draw_spec, &DrawType, "Draw"},
-        {&pen_spec, &PenType, "Pen"},
-        {&brush_spec, &BrushType, "Brush"},
-        {&font_spec, &FontType, "Font"},
-        {&path_spec, &PathType, "Path"},
+        {&draw_spec, &DrawType, "Draw", NULL},
+        {&pen_spec, &PenType, "Pen", NULL},
+        {&brush_spec, &BrushType, "Brush", NULL},
+        {&font_spec, &FontType, "Font", NULL},
+        {&path_spec, &PathType, "Path", NULL},
+        /* Ordering matters: a row naming a base must come after the row that
+           creates it, since the base is read from *types[i].base right here. */
+        {&symbol_spec, &SymbolType, "Symbol", &PathType},
     };
 
     for (size_t i = 0; i < sizeof(types)/sizeof(types[0]); i++) {
-        PyObject* type = PyType_FromSpec(types[i].spec);
+        PyObject* bases = NULL;
+        if (types[i].base != NULL) {
+            bases = Py_BuildValue("(O)", (PyObject*) *types[i].base);
+            if (bases == NULL) {
+                Py_DECREF(module);
+                return NULL;
+            }
+        }
+        PyObject* type = PyType_FromSpecWithBases(types[i].spec, bases);
+        Py_XDECREF(bases);  /* the new type holds its own reference */
         if (type == NULL) {
             Py_DECREF(module);
             return NULL;

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -117,26 +117,18 @@ typedef struct {
 /* glue functions (see the init function for details) */
 static PyObject* aggdraw_getcolor_obj;
 
-static void draw_dealloc(DrawObject* self);
-static PyObject* draw_getattro(DrawObject* self, PyObject* nameobj);
-static PyTypeObject DrawType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Draw", sizeof(DrawObject), 0,
-    /* methods */
-    (destructor) draw_dealloc, /* tp_dealloc */
-    0, /* tp_vectorcall_offset */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-    0, /* tp_as_async */
-    0, /* tp_repr */
-    0, /* tp_as_number */
-    0, /* tp_as_sequence */
-    0, /* tp_as_mapping */
-    0, /* tp_hash */
-    0, /* tp_call */
-    0, /* tp_str */
-    (getattrofunc)draw_getattro, /* tp_getattro */
-};
+/* All five types are heap types, created with PyType_FromSpec in aggdraw_init
+   and exposed on the module as real classes. Each PyType_Spec is defined next
+   to that type's own methods, further down the file. */
+static PyTypeObject* DrawType;
+static PyTypeObject* PenType;
+static PyTypeObject* BrushType;
+static PyTypeObject* FontType;
+static PyTypeObject* PathType;
+
+/* The _Check macros use PyObject_TypeCheck rather than an identity test: the
+   types set Py_TPFLAGS_BASETYPE, and an identity test would make
+   draw_adaptor::draw silently ignore a subclass of Pen or Brush. */
 
 typedef struct {
     PyObject_HEAD
@@ -144,37 +136,14 @@ typedef struct {
     float width;
 } PenObject;
 
-static void pen_dealloc(PenObject* self);
-
-static PyTypeObject PenType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Pen", sizeof(PenObject), 0,
-    /* methods */
-    (destructor) pen_dealloc, /* tp_dealloc */
-    0, /* tp_vectorcall_offset */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-};
-
-#define Pen_Check(op) ((op) != NULL && Py_TYPE(op) == &PenType)
+#define Pen_Check(op) ((op) != NULL && PyObject_TypeCheck(op, PenType))
 
 typedef struct {
     PyObject_HEAD
     agg::rgba8 color;
 } BrushObject;
 
-static void brush_dealloc(BrushObject* self);
-
-static PyTypeObject BrushType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Brush", sizeof(BrushObject), 0,
-    /* methods */
-    (destructor) brush_dealloc, /* tp_dealloc */
-    0, /* tp_vectorcall_offset */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-};
-#define Brush_Check(op) ((op) != NULL && Py_TYPE(op) == &BrushType)
+#define Brush_Check(op) ((op) != NULL && PyObject_TypeCheck(op, BrushType))
 
 typedef struct {
     PyObject_HEAD
@@ -187,48 +156,17 @@ typedef struct {
 static FT_Face font_load(FontObject* font, bool outline=false);
 #endif
 
+/* Defined below the getset block, which the Font spec needs to name first. */
 static void font_dealloc(FontObject* self);
-static PyObject* font_getattro(FontObject* self, PyObject* nameobj);
-static PyTypeObject FontType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Font", sizeof(FontObject), 0,
-    /* methods */
-    (destructor) font_dealloc, /* tp_dealloc */
-    0, /* tp_vectorcall_offset */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-    0, /* tp_as_async */
-    0, /* tp_repr */
-    0, /* tp_as_number */
-    0, /* tp_as_sequence */
-    0, /* tp_as_mapping */
-    0, /* tp_hash */
-    0, /* tp_call */
-    0, /* tp_str */
-    (getattrofunc)font_getattro, /* tp_getattro */
-};
 
-#define Font_Check(op) ((op) != NULL && Py_TYPE(op) == &FontType)
+#define Font_Check(op) ((op) != NULL && PyObject_TypeCheck(op, FontType))
 
 typedef struct {
     PyObject_HEAD
     agg::path_storage* path;
 } PathObject;
 
-static void path_dealloc(PathObject* self);
-/* tp_getattro is left unset: PyType_Ready() inherits PyObject_GenericGetAttr
-   from PyBaseObject_Type, which is all Path needs. */
-static PyTypeObject PathType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Path", sizeof(PathObject), 0,
-    /* methods */
-    (destructor) path_dealloc, /* tp_dealloc */
-    0, /* tp_vectorcall_offset */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-};
-
-#define Path_Check(op) ((op) != NULL && Py_TYPE(op) == &PathType)
+#define Path_Check(op) ((op) != NULL && PyObject_TypeCheck(op, PathType))
 
 static agg::rgba8 getcolor(PyObject* color, int opacity=255);
 
@@ -496,7 +434,7 @@ const char *draw_doc = "Creates a drawing interface object.\n"
                        "    >>> d = aggdraw.Draw(\"RGB\", (800, 600), \"white\")\n";
 
 static PyObject*
-draw_new(PyObject* self_, PyObject* args)
+draw_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
     char buffer[10];
     int ok;
@@ -557,7 +495,7 @@ draw_new(PyObject* self_, PyObject* args)
         image = NULL;
     }
 
-    DrawObject* self = PyObject_NEW(DrawObject, &DrawType);
+    DrawObject* self = (DrawObject*) type->tp_alloc(type, 0);
     if (self == NULL)
         return NULL;
 
@@ -1195,7 +1133,7 @@ draw_path(DrawObject* self, PyObject* args){
     PyObject*   brush = NULL;
     PyObject*   pen   = NULL;
 
-    if (!PyArg_ParseTuple(args, "O!|OO:path", &PathType, &path, &brush, &pen)){
+    if (!PyArg_ParseTuple(args, "O!|OO:path", PathType, &path, &brush, &pen)){
         return NULL;
     }
 
@@ -1237,7 +1175,7 @@ draw_symbol(DrawObject* self, PyObject* args)
     PyObject* brush = NULL;
     PyObject* pen = NULL;
     if (!PyArg_ParseTuple(args, "OO!|OO:symbol",
-                          &xyIn, &PathType, &symbol, &brush, &pen))
+                          &xyIn, PathType, &symbol, &brush, &pen))
         return NULL;
 
     int count;
@@ -1280,7 +1218,7 @@ draw_text(DrawObject* self, PyObject* args)
     PyObject* text;
     FontObject* font;
     if (!PyArg_ParseTuple(args, "(ff)OO!:text", xy+0, xy+1, &text,
-                          &FontType, &font))
+                          FontType, &font))
         return NULL;
 
     self->draw->drawtext(xy, text, font);
@@ -1312,7 +1250,7 @@ draw_textsize(DrawObject* self, PyObject* args)
 {
     PyObject* text;
     FontObject* font;
-    if (!PyArg_ParseTuple(args, "OO!:textsize", &text, &FontType, &font))
+    if (!PyArg_ParseTuple(args, "OO!:textsize", &text, FontType, &font))
         return NULL;
 
     FT_Face face = font_load(font);
@@ -1506,7 +1444,9 @@ draw_dealloc(DrawObject* self)
     Py_XDECREF(self->background);
     Py_XDECREF(self->image);
 
-    PyObject_DEL(self);
+    PyTypeObject* tp = Py_TYPE(self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 }
 
 static PyMethodDef draw_methods[] = {
@@ -1543,20 +1483,48 @@ static PyMethodDef draw_methods[] = {
 };
 
 static PyObject*
-draw_getattro(DrawObject* self, PyObject* nameobj)
+draw_get_mode(DrawObject* self, void* closure)
 {
-    if (!PyUnicode_Check(nameobj))
-        goto generic;
-
-    if (PyUnicode_CompareWithASCIIString(nameobj, "mode") == 0)
-        return PyUnicode_FromString(self->draw->mode);
-    if (PyUnicode_CompareWithASCIIString(nameobj, "size") == 0)
-        return Py_BuildValue(
-            "(ii)", self->buffer->width(), self->buffer->height()
-            );
-  generic:
-    return PyObject_GenericGetAttr((PyObject*)self, nameobj);
+    /* This is the adaptor's label, not the mode the surface was created with.
+       A BGRA surface is rendered by the RGBA adaptor and so reports "RGBA". */
+    return PyUnicode_FromString(self->draw->mode);
 }
+
+static PyObject*
+draw_get_size(DrawObject* self, void* closure)
+{
+    return Py_BuildValue(
+        "(ii)", self->buffer->width(), self->buffer->height()
+        );
+}
+
+static PyGetSetDef draw_getset[] = {
+    {"mode", (getter) draw_get_mode, NULL,
+     (char*) "str: The mode of the drawing surface, e.g. \"RGB\".", NULL},
+    {"size", (getter) draw_get_size, NULL,
+     (char*) "tuple: The size of the drawing surface as (width, height).", NULL},
+    {NULL}
+};
+
+/* PyType_Slot stores a void*, but the *_doc constants are const char*. */
+#define DOC_SLOT(d) ((void*) const_cast<char*>(d))
+
+static PyType_Slot draw_slots[] = {
+    {Py_tp_new, (void*) draw_new},
+    {Py_tp_dealloc, (void*) draw_dealloc},
+    {Py_tp_methods, (void*) draw_methods},
+    {Py_tp_getset, (void*) draw_getset},
+    {Py_tp_doc, DOC_SLOT(draw_doc)},
+    {0, NULL}
+};
+
+static PyType_Spec draw_spec = {
+    "aggdraw._aggdraw.Draw",
+    sizeof(DrawObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    draw_slots
+};
 
 /* -------------------------------------------------------------------- */
 
@@ -1578,7 +1546,7 @@ const char *pen_doc = "Creates a Pen object.\n"
                       "    Pen opacity. Default 255.\n";
 
 static PyObject*
-pen_new(PyObject* self_, PyObject* args, PyObject* kw)
+pen_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
     PenObject* self;
 
@@ -1590,7 +1558,7 @@ pen_new(PyObject* self_, PyObject* args, PyObject* kw)
                                      &color, &width, &opacity))
         return NULL;
 
-    self = PyObject_NEW(PenObject, &PenType);
+    self = (PenObject*) type->tp_alloc(type, 0);
 
     if (self == NULL)
         return NULL;
@@ -1604,8 +1572,48 @@ pen_new(PyObject* self_, PyObject* args, PyObject* kw)
 static void
 pen_dealloc(PenObject* self)
 {
-    PyObject_DEL(self);
+    PyTypeObject* tp = Py_TYPE(self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 }
+
+static PyObject*
+pen_get_color(PenObject* self, void* closure)
+{
+    return Py_BuildValue(
+        "(BBBB)", self->color.r, self->color.g, self->color.b, self->color.a
+        );
+}
+
+static PyObject*
+pen_get_width(PenObject* self, void* closure)
+{
+    return PyFloat_FromDouble(self->width);
+}
+
+static PyGetSetDef pen_getset[] = {
+    {"color", (getter) pen_get_color, NULL,
+     (char*) "tuple: The pen color, as resolved, in (R, G, B, A) form.", NULL},
+    {"width", (getter) pen_get_width, NULL,
+     (char*) "float: The width of the pen.", NULL},
+    {NULL}
+};
+
+static PyType_Slot pen_slots[] = {
+    {Py_tp_new, (void*) pen_new},
+    {Py_tp_dealloc, (void*) pen_dealloc},
+    {Py_tp_getset, (void*) pen_getset},
+    {Py_tp_doc, DOC_SLOT(pen_doc)},
+    {0, NULL}
+};
+
+static PyType_Spec pen_spec = {
+    "aggdraw._aggdraw.Pen",
+    sizeof(PenObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    pen_slots
+};
 
 /* -------------------------------------------------------------------- */
 
@@ -1625,7 +1633,7 @@ const char *brush_doc = "Creates a brush object.\n"
                         "    Brush opacity. Default 255.\n";
 
 static PyObject*
-brush_new(PyObject* self_, PyObject* args, PyObject* kw)
+brush_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
     BrushObject* self;
 
@@ -1636,7 +1644,7 @@ brush_new(PyObject* self_, PyObject* args, PyObject* kw)
                                      &color, &opacity))
         return NULL;
 
-    self = PyObject_NEW(BrushObject, &BrushType);
+    self = (BrushObject*) type->tp_alloc(type, 0);
 
     if (self == NULL)
         return NULL;
@@ -1649,8 +1657,40 @@ brush_new(PyObject* self_, PyObject* args, PyObject* kw)
 static void
 brush_dealloc(BrushObject* self)
 {
-    PyObject_DEL(self);
+    PyTypeObject* tp = Py_TYPE(self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 }
+
+static PyObject*
+brush_get_color(BrushObject* self, void* closure)
+{
+    return Py_BuildValue(
+        "(BBBB)", self->color.r, self->color.g, self->color.b, self->color.a
+        );
+}
+
+static PyGetSetDef brush_getset[] = {
+    {"color", (getter) brush_get_color, NULL,
+     (char*) "tuple: The brush color, as resolved, in (R, G, B, A) form.", NULL},
+    {NULL}
+};
+
+static PyType_Slot brush_slots[] = {
+    {Py_tp_new, (void*) brush_new},
+    {Py_tp_dealloc, (void*) brush_dealloc},
+    {Py_tp_getset, (void*) brush_getset},
+    {Py_tp_doc, DOC_SLOT(brush_doc)},
+    {0, NULL}
+};
+
+static PyType_Spec brush_spec = {
+    "aggdraw._aggdraw.Brush",
+    sizeof(BrushObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    brush_slots
+};
 
 
 /* -------------------------------------------------------------------- */
@@ -1675,7 +1715,7 @@ const char *font_doc = "Create a font object from a truetype font file for use w
                        "    Font opacity. Default 255.\n";
 
 static PyObject*
-font_new(PyObject* self_, PyObject* args, PyObject* kw)
+font_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
     PyObject* color;
     char* filename;
@@ -1687,7 +1727,7 @@ font_new(PyObject* self_, PyObject* args, PyObject* kw)
         return NULL;
 
 #if defined(HAVE_FREETYPE2)
-    FontObject* self = PyObject_NEW(FontObject, &FontType);
+    FontObject* self = (FontObject*) type->tp_alloc(type, 0);
 
     if (self == NULL)
         return NULL;
@@ -1711,10 +1751,6 @@ font_new(PyObject* self_, PyObject* args, PyObject* kw)
 #endif
 }
 
-static PyMethodDef font_methods[] = {
-    {NULL, NULL}
-};
-
 #if defined(HAVE_FREETYPE2)
 static FT_Face
 font_load(FontObject* font, bool outline)
@@ -1733,60 +1769,93 @@ font_load(FontObject* font, bool outline)
 }
 #endif
 
-static PyObject*
-font_getattro(FontObject* self, PyObject* nameobj)
-{
-    if (!PyUnicode_Check(nameobj))
-        goto generic;
-
 #if defined(HAVE_FREETYPE2)
-    FT_Face face;
-    if (PyUnicode_CompareWithASCIIString(nameobj, "family") == 0)
-    {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyUnicode_FromString(face->family_name);
+/* Each of these reloads the face: FontObject stores only the filename, and the
+   shared font_engine may have been pointed at a different font since. A face
+   that will not load yields None rather than an exception, as it always has. */
+static PyObject*
+font_get_family(FontObject* self, void* closure)
+{
+    FT_Face face = font_load(self);
+    if (!face) {
+        Py_INCREF(Py_None);
+        return Py_None;
     }
-    if (PyUnicode_CompareWithASCIIString(nameobj, "style") == 0)
-    {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyUnicode_FromString(face->style_name);
-    }
-    if (PyUnicode_CompareWithASCIIString(nameobj, "ascent") == 0)
-    {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyFloat_FromDouble(face->size->metrics.ascender/64.0);
-    }
-    if (PyUnicode_CompareWithASCIIString(nameobj, "descent") == 0)
-    {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyFloat_FromDouble(-face->size->metrics.descender/64.0);
-    }
-#endif
-  generic:
-    return PyObject_GenericGetAttr((PyObject*)self, nameobj);
+    return PyUnicode_FromString(face->family_name);
 }
+
+static PyObject*
+font_get_style(FontObject* self, void* closure)
+{
+    FT_Face face = font_load(self);
+    if (!face) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    return PyUnicode_FromString(face->style_name);
+}
+
+static PyObject*
+font_get_ascent(FontObject* self, void* closure)
+{
+    FT_Face face = font_load(self);
+    if (!face) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    return PyFloat_FromDouble(face->size->metrics.ascender/64.0);
+}
+
+static PyObject*
+font_get_descent(FontObject* self, void* closure)
+{
+    FT_Face face = font_load(self);
+    if (!face) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    return PyFloat_FromDouble(-face->size->metrics.descender/64.0);
+}
+#endif
+
+static PyGetSetDef font_getset[] = {
+#if defined(HAVE_FREETYPE2)
+    {"family", (getter) font_get_family, NULL,
+     (char*) "str: The font family name reported by FreeType.", NULL},
+    {"style", (getter) font_get_style, NULL,
+     (char*) "str: The font style name reported by FreeType.", NULL},
+    {"ascent", (getter) font_get_ascent, NULL,
+     (char*) "float: The font ascent, in pixels.", NULL},
+    {"descent", (getter) font_get_descent, NULL,
+     (char*) "float: The font descent, in pixels, as a positive number.", NULL},
+#endif
+    {NULL}
+};
+
+static PyType_Slot font_slots[] = {
+    {Py_tp_new, (void*) font_new},
+    {Py_tp_dealloc, (void*) font_dealloc},
+    {Py_tp_getset, (void*) font_getset},
+    {Py_tp_doc, DOC_SLOT(font_doc)},
+    {0, NULL}
+};
+
+static PyType_Spec font_spec = {
+    "aggdraw._aggdraw.Font",
+    sizeof(FontObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    font_slots
+};
 
 static void
 font_dealloc(FontObject* self)
 {
     delete [] self->filename;
-    PyObject_DEL(self);
+
+    PyTypeObject* tp = Py_TYPE(self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 }
 
 /* -------------------------------------------------------------------- */
@@ -1801,13 +1870,13 @@ const char *path_doc = "Path factory (experimental).\n"
                        "    line segment to each remaining pair.\n";
 
 static PyObject*
-path_new(PyObject* self_, PyObject* args)
+path_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
     PyObject* xyIn = NULL;
     if (!PyArg_ParseTuple(args, "|O:Path", &xyIn))
         return NULL;
 
-    PathObject* self = PyObject_NEW(PathObject, &PathType);
+    PathObject* self = (PathObject*) type->tp_alloc(type, 0);
 
     if (self == NULL)
         return NULL;
@@ -1818,7 +1887,7 @@ path_new(PyObject* self_, PyObject* args)
         int count;
         PointF *xy = getpoints(xyIn, &count);
         if (!xy) {
-            path_dealloc(self);
+            Py_DECREF(self);
             return NULL;
         }
         self->path->move_to(xy[0].X, xy[0].Y);
@@ -1852,7 +1921,7 @@ symbol_new(PyObject* self_, PyObject* args)
     if (!PyArg_ParseTuple(args, "s|f:Symbol", &path, &scale))
         return NULL;
 
-    PathObject* self = PyObject_NEW(PathObject, &PathType);
+    PathObject* self = (PathObject*) PathType->tp_alloc(PathType, 0);
 
     if (self == NULL)
         return NULL;
@@ -2290,7 +2359,10 @@ static void
 path_dealloc(PathObject* self)
 {
     delete self->path;
-    PyObject_DEL(self);
+
+    PyTypeObject* tp = Py_TYPE(self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 }
 
 static PyMethodDef path_methods[] = {
@@ -2311,15 +2383,29 @@ static PyMethodDef path_methods[] = {
     {NULL, NULL}
 };
 
+static PyType_Slot path_slots[] = {
+    {Py_tp_new, (void*) path_new},
+    {Py_tp_dealloc, (void*) path_dealloc},
+    {Py_tp_methods, (void*) path_methods},
+    {Py_tp_doc, DOC_SLOT(path_doc)},
+    {0, NULL}
+};
+
+static PyType_Spec path_spec = {
+    "aggdraw._aggdraw.Path",
+    sizeof(PathObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    path_slots
+};
+
 /* -------------------------------------------------------------------- */
 
+/* Pen, Brush, Font, Path and Draw are types, added to the module in
+   aggdraw_init. Symbol stays a factory function because it returns a Path --
+   Symbol and Path have always been the same C type. */
 static PyMethodDef aggdraw_functions[] = {
-    {"Pen", (PyCFunction) pen_new, METH_VARARGS|METH_KEYWORDS, pen_doc},
-    {"Brush", (PyCFunction) brush_new, METH_VARARGS|METH_KEYWORDS, brush_doc},
-    {"Font", (PyCFunction) font_new, METH_VARARGS|METH_KEYWORDS, font_doc},
     {"Symbol", (PyCFunction) symbol_new, METH_VARARGS, symbol_doc},
-    {"Path", (PyCFunction) path_new, METH_VARARGS, path_doc},
-    {"Draw", (PyCFunction) draw_new, METH_VARARGS, draw_doc},
     {NULL, NULL}
 };
 
@@ -2363,39 +2449,42 @@ static struct PyModuleDef moduledef = {
 static PyObject *
 aggdraw_init(void)
 {
-    /* tp_methods must be assigned before PyType_Ready: PyType_Ready copies
-       tp_methods into tp_dict once and never looks at it again. (The arrays
-       are defined further down the file, and C++ has no tentative
-       definitions, so they cannot be named from the static initializers.)
-       Pen and Brush expose no methods. */
-    DrawType.tp_methods = draw_methods;
-    FontType.tp_methods = font_methods;
-    PathType.tp_methods = path_methods;
-
-    DrawType.tp_flags = Py_TPFLAGS_DEFAULT;
-    PenType.tp_flags = Py_TPFLAGS_DEFAULT;
-    BrushType.tp_flags = Py_TPFLAGS_DEFAULT;
-    FontType.tp_flags = Py_TPFLAGS_DEFAULT;
-    PathType.tp_flags = Py_TPFLAGS_DEFAULT;
-
-    /* Without this the types keep a NULL ob_type and type(obj) crashes.
-       Note: Py_TPFLAGS_BASETYPE is deliberately NOT set -- the deallocators
-       call PyObject_DEL directly rather than going through tp_free, which is
-       only safe as long as these types cannot be subclassed. */
-    if (PyType_Ready(&DrawType) < 0)
-        return NULL;
-    if (PyType_Ready(&PenType) < 0)
-        return NULL;
-    if (PyType_Ready(&BrushType) < 0)
-        return NULL;
-    if (PyType_Ready(&FontType) < 0)
-        return NULL;
-    if (PyType_Ready(&PathType) < 0)
-        return NULL;
-
     PyObject *module = PyModule_Create(&moduledef);
     if (module == NULL)
         return NULL;
+
+    /* Build the five types from their specs and expose them as real classes.
+       PyType_FromSpec fills in ob_type, so type() and help() work; each spec
+       names its own tp_new, so the types are directly constructible and
+       Py_TPFLAGS_BASETYPE lets them be subclassed. The deallocators go through
+       tp_free and drop a reference on the type, as heap types require. */
+    static const struct {
+        PyType_Spec* spec;
+        PyTypeObject** slot;
+        const char* name;
+    } types[] = {
+        {&draw_spec, &DrawType, "Draw"},
+        {&pen_spec, &PenType, "Pen"},
+        {&brush_spec, &BrushType, "Brush"},
+        {&font_spec, &FontType, "Font"},
+        {&path_spec, &PathType, "Path"},
+    };
+
+    for (size_t i = 0; i < sizeof(types)/sizeof(types[0]); i++) {
+        PyObject* type = PyType_FromSpec(types[i].spec);
+        if (type == NULL) {
+            Py_DECREF(module);
+            return NULL;
+        }
+        *types[i].slot = (PyTypeObject*) type;
+        if (PyModule_AddObjectRef(module, types[i].name, type) < 0) {
+            Py_DECREF(type);
+            Py_DECREF(module);
+            return NULL;
+        }
+        /* The module holds its own reference; the file-scope pointer above
+           keeps one for the C code's own type checks. */
+    }
 
     PyObject *version = PyUnicode_FromString(QUOTE(VERSION));
     if (version == NULL) {

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -436,6 +436,14 @@ const char *draw_doc = "Creates a drawing interface object.\n"
 static PyObject*
 draw_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
+    /* tp_new is handed keywords whether or not it wants them; the old
+       METH_VARARGS entry point rejected them, so keep doing that rather than
+       accepting and ignoring them. */
+    if (kw != NULL && PyDict_GET_SIZE(kw) != 0) {
+        PyErr_SetString(PyExc_TypeError, "Draw() takes no keyword arguments");
+        return NULL;
+    }
+
     char buffer[10];
     int ok;
 
@@ -1872,6 +1880,11 @@ const char *path_doc = "Path factory (experimental).\n"
 static PyObject*
 path_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {
+    if (kw != NULL && PyDict_GET_SIZE(kw) != 0) {
+        PyErr_SetString(PyExc_TypeError, "Path() takes no keyword arguments");
+        return NULL;
+    }
+
     PyObject* xyIn = NULL;
     if (!PyArg_ParseTuple(args, "|O:Path", &xyIn))
         return NULL;

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -561,6 +561,16 @@ draw_new(PyObject* self_, PyObject* args)
     if (self == NULL)
         return NULL;
 
+    /* PyObject_NEW does not zero the allocation and draw_dealloc deletes every
+       pointer field, so they must all be valid before any error path below can
+       Py_DECREF(self). */
+    self->draw = NULL;
+    self->buffer = NULL;
+    self->transform = NULL;
+    self->buffer_data = NULL;
+    self->image = NULL;
+    self->background = NULL;
+
     int stride;
     if (!strcmp(mode, "L")) {
         self->mode = agg::pix_format_gray8;
@@ -579,7 +589,7 @@ draw_new(PyObject* self_, PyObject* args)
         stride = xsize * 4;
     } else {
         PyErr_SetString(PyExc_ValueError, "bad mode");
-        PyObject_DEL(self);
+        Py_DECREF(self);
         return NULL;
     }
 
@@ -598,19 +608,23 @@ draw_new(PyObject* self_, PyObject* args)
     self->xsize = xsize;
     self->ysize = ysize;
 
-    self->transform = NULL;
-
+    /* Take the reference at the point of assignment, not after the round-trip
+       below: until this incref runs the struct holds a borrowed pointer. */
+    Py_XINCREF(image);
     self->image = image;
     if (image) {
         PyObject* buffer = PyObject_CallMethod(image, "tobytes", NULL);
-        if (!buffer)
-            return NULL; /* FIXME: release resources */
+        if (!buffer) {
+            Py_DECREF(self);
+            return NULL;
+        }
         if (!PyBytes_Check(buffer)) {
             PyErr_SetString(
                 PyExc_TypeError,
                 "bad 'tobytes' return value (expected string)"
                 );
             Py_DECREF(buffer);
+            Py_DECREF(self);
             return NULL;
         }
         char* data = PyBytes_AS_STRING(buffer);
@@ -620,9 +634,9 @@ draw_new(PyObject* self_, PyObject* args)
         else {
             PyErr_SetString(PyExc_ValueError, "not enough data");
             Py_DECREF(buffer);
-            return NULL; /* FIXME: release resources */
+            Py_DECREF(self);
+            return NULL;
         }
-        Py_INCREF(image); /* hang on to this image */
         Py_DECREF(buffer);
     }
 
@@ -1486,6 +1500,7 @@ draw_dealloc(DrawObject* self)
 {
     delete self->draw;
     delete self->buffer;
+    delete self->transform;
     delete [] self->buffer_data;
 
     Py_XDECREF(self->background);
@@ -1685,6 +1700,7 @@ font_new(PyObject* self_, PyObject* args, PyObject* kw)
 
     if (!font_load(self)) {
         PyErr_SetString(PyExc_IOError, "cannot load font");
+        Py_DECREF(self);
         return NULL;
     }
 
@@ -1867,6 +1883,7 @@ symbol_new(PyObject* self_, PyObject* args)
                 PyErr_Format(
                     PyExc_ValueError, "no command at start of path"
                     );
+                Py_DECREF(self);
                 return NULL;
             }
             COMMA_WSP;
@@ -1988,7 +2005,7 @@ symbol_new(PyObject* self_, PyObject* args)
                 PyExc_ValueError,
                 "unknown path command '%c'", op
                 );
-            /* FIXME: cleanup */
+            Py_DECREF(self);
             return NULL;
         }
         if (p == q) {
@@ -1996,7 +2013,7 @@ symbol_new(PyObject* self_, PyObject* args)
                 PyExc_ValueError,
                 "invalid arguments for command '%c'", op
                 );
-            /* FIXME: cleanup */
+            Py_DECREF(self);
             return NULL;
         }
     }
@@ -2224,6 +2241,20 @@ const char *path_coords_doc = "Returns the coordinates for this path.\n"
                               "\n"
                               "Curves are flattened before being returned.\n";
 
+/* Append a float to a list, releasing the temporary. PyList_Append takes its
+   own reference, so the one returned by PyFloat_FromDouble must be dropped or
+   every coordinate leaks an object. */
+static int
+append_float(PyObject* list, double value)
+{
+    PyObject* item = PyFloat_FromDouble(value);
+    if (!item)
+        return -1;
+    int status = PyList_Append(list, item);
+    Py_DECREF(item);
+    return status;
+}
+
 static PyObject*
 path_coords(PathObject* self, PyObject* args)
 {
@@ -2245,10 +2276,10 @@ path_coords(PathObject* self, PyObject* args)
     unsigned cmd;
     while (!agg::is_stop(cmd = curve.vertex(&x, &y))) {
         if (agg::is_vertex(cmd)) {
-            if (PyList_Append(list, PyFloat_FromDouble(x)) < 0)
+            if (append_float(list, x) < 0 || append_float(list, y) < 0) {
+                Py_DECREF(list);
                 return NULL;
-            if (PyList_Append(list, PyFloat_FromDouble(y)) < 0)
-                return NULL;
+            }
         }
     }
 
@@ -2381,8 +2412,16 @@ aggdraw_init(void)
     }
 
     PyObject* g = PyDict_New();
-    PyDict_SetItemString(g, "__builtins__", PyEval_GetBuiltins());
-    PyRun_String(
+    if (g == NULL) {
+        Py_DECREF(module);
+        return NULL;
+    }
+    if (PyDict_SetItemString(g, "__builtins__", PyEval_GetBuiltins()) < 0) {
+        Py_DECREF(g);
+        Py_DECREF(module);
+        return NULL;
+    }
+    PyObject* result = PyRun_String(
         "try:\n"
         "    from PIL import ImageColor\n"
         "except ImportError:\n"
@@ -2394,12 +2433,18 @@ aggdraw_init(void)
         "", Py_file_input, g, NULL
 
         );
+    if (result == NULL) {
+        Py_DECREF(g);
+        Py_DECREF(module);
+        return NULL;
+    }
+    Py_DECREF(result);
 
-    /* Borrowed reference. `g` is deliberately leaked: it is what keeps
-       aggdraw_getcolor_obj alive for the lifetime of the module. Do not
-       "tidy up" with Py_DECREF(g) -- that turns every getcolor() call into
-       a use-after-free. */
+    /* PyDict_GetItemString returns a borrowed reference, so take a strong one
+       of our own before releasing the dict that owns it. */
     aggdraw_getcolor_obj = PyDict_GetItemString(g, "getcolor");
+    Py_XINCREF(aggdraw_getcolor_obj);
+    Py_DECREF(g);
 
 #ifdef Py_GIL_DISABLED
     PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);

--- a/aggdraw/_aggdraw.cxx
+++ b/aggdraw/_aggdraw.cxx
@@ -41,6 +41,7 @@
  * 2017-08-18 dh   fixed mode to be python str instead of bytes
  * 2017-08-18 dh   fixed a couple compiler warnings (specifically clang)
  * 2018-04-21 dh   fixed python 2 compatibility in getcolor
+ * 2026-08-24 dh   dropped Python 2 support code; ready types at import
  *
  * Copyright (c) 2011-2017 by AggDraw Developers
  *
@@ -61,18 +62,6 @@
 #define PY_SSIZE_T_CLEAN 1
 
 #include "Python.h"
-#if PY_MAJOR_VERSION >= 3
-#define IS_PY3K
-#define HAVE_UNICODE
-#endif
-#include "bytesobject.h"
-
-#if defined(PY_VERSION_HEX) && PY_VERSION_HEX >= 0x01060000
-#if PY_VERSION_HEX  < 0x02020000 || defined(Py_USING_UNICODE)
-/* defining this enables unicode support (default under 1.6a1 and later) */
-#define HAVE_UNICODE
-#endif
-#endif
 
 /* agg2 components */
 #include "agg_arc.h"
@@ -125,47 +114,29 @@ typedef struct {
     PyObject* background;
 } DrawObject;
 
-#ifndef Py_TYPE
-    #define Py_TYPE(ob) (((PyObject*)(ob))->ob_type)
-#endif
-
 /* glue functions (see the init function for details) */
 static PyObject* aggdraw_getcolor_obj;
 
 static void draw_dealloc(DrawObject* self);
-#ifdef IS_PY3K
 static PyObject* draw_getattro(DrawObject* self, PyObject* nameobj);
 static PyTypeObject DrawType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "Draw", sizeof(DrawObject), 0,
     /* methods */
     (destructor) draw_dealloc, /* tp_dealloc */
-    0, /* tp_print */
+    0, /* tp_vectorcall_offset */
     0, /* tp_getattr */
     0, /* tp_setattr */
-    0, /* tp_reserved */
+    0, /* tp_as_async */
     0, /* tp_repr */
     0, /* tp_as_number */
     0, /* tp_as_sequence */
     0, /* tp_as_mapping */
-    0, /* tp_hash*/
-    0, /* tp_call*/
-    0, /* tp_str*/
+    0, /* tp_hash */
+    0, /* tp_call */
+    0, /* tp_str */
     (getattrofunc)draw_getattro, /* tp_getattro */
 };
-#else
-
-static PyObject* draw_getattr(DrawObject* self, char* name);
-static PyTypeObject DrawType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Draw", sizeof(DrawObject), 0,
-    /* methods */
-    (destructor) draw_dealloc, /* tp_dealloc */
-    (printfunc)0, /* tp_print */
-    (getattrfunc)draw_getattr, /* tp_getattr */
-    0, /* tp_setattr */
-};
-#endif
 
 typedef struct {
     PyObject_HEAD
@@ -175,28 +146,15 @@ typedef struct {
 
 static void pen_dealloc(PenObject* self);
 
-#ifdef IS_PY3K
 static PyTypeObject PenType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "Pen", sizeof(PenObject), 0,
     /* methods */
     (destructor) pen_dealloc, /* tp_dealloc */
-    0, /* tp_print */
+    0, /* tp_vectorcall_offset */
     0, /* tp_getattr */
     0, /* tp_setattr */
 };
-
-#else
-static PyTypeObject PenType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Pen", sizeof(PenObject), 0,
-    /* methods */
-    (destructor) pen_dealloc, /* tp_dealloc */
-    0, /* tp_print */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-};
-#endif
 
 #define Pen_Check(op) ((op) != NULL && Py_TYPE(op) == &PenType)
 
@@ -207,29 +165,15 @@ typedef struct {
 
 static void brush_dealloc(BrushObject* self);
 
-#ifdef IS_PY3K
 static PyTypeObject BrushType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "Brush", sizeof(BrushObject), 0,
     /* methods */
     (destructor) brush_dealloc, /* tp_dealloc */
-    0, /* tp_print */
+    0, /* tp_vectorcall_offset */
     0, /* tp_getattr */
     0, /* tp_setattr */
 };
-
-#else
-static PyTypeObject BrushType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Brush", sizeof(BrushObject), 0,
-    /* methods */
-    (destructor) brush_dealloc, /* tp_dealloc */
-    0, /* tp_print */
-    0, /* tp_getattr */
-    0, /* tp_setattr */
-};
-
-#endif
 #define Brush_Check(op) ((op) != NULL && Py_TYPE(op) == &BrushType)
 
 typedef struct {
@@ -244,38 +188,25 @@ static FT_Face font_load(FontObject* font, bool outline=false);
 #endif
 
 static void font_dealloc(FontObject* self);
-#ifdef IS_PY3K
 static PyObject* font_getattro(FontObject* self, PyObject* nameobj);
 static PyTypeObject FontType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "Font", sizeof(FontObject), 0,
     /* methods */
     (destructor) font_dealloc, /* tp_dealloc */
-    (printfunc)0, /* tp_print */
+    0, /* tp_vectorcall_offset */
     0, /* tp_getattr */
     0, /* tp_setattr */
-    0, /* tp_reserved */
-    (reprfunc)0, /* tp_repr */
+    0, /* tp_as_async */
+    0, /* tp_repr */
     0, /* tp_as_number */
     0, /* tp_as_sequence */
     0, /* tp_as_mapping */
-    (hashfunc)0,  /*tp_hash*/
-    (ternaryfunc)0,  /*tp_call*/
-    (reprfunc)0,  /*tp_str*/
+    0, /* tp_hash */
+    0, /* tp_call */
+    0, /* tp_str */
     (getattrofunc)font_getattro, /* tp_getattro */
 };
-#else
-static PyObject* font_getattr(FontObject* self, char* name);
-static PyTypeObject FontType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Font", sizeof(FontObject), 0,
-    /* methods */
-    (destructor) font_dealloc, /* tp_dealloc */
-    0, /* tp_print */
-    (getattrfunc) font_getattr, /* tp_getattr */
-    0, /* tp_setattr */
-};
-#endif
 
 #define Font_Check(op) ((op) != NULL && Py_TYPE(op) == &FontType)
 
@@ -285,38 +216,17 @@ typedef struct {
 } PathObject;
 
 static void path_dealloc(PathObject* self);
-#ifdef IS_PY3K
-static PyObject* path_getattro(PathObject* self, PyObject* nameobj);
+/* tp_getattro is left unset: PyType_Ready() inherits PyObject_GenericGetAttr
+   from PyBaseObject_Type, which is all Path needs. */
 static PyTypeObject PathType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "Path", sizeof(PathObject), 0,
     /* methods */
     (destructor) path_dealloc, /* tp_dealloc */
-    (printfunc)0, /* tp_print */
+    0, /* tp_vectorcall_offset */
     0, /* tp_getattr */
     0, /* tp_setattr */
-    0, /* tp_reserved */
-    (reprfunc)0, /* tp_repr */
-    0, /* tp_as_number */
-    0, /* tp_as_sequence */
-    0, /* tp_as_mapping */
-    (hashfunc)0,  /*tp_hash*/
-    (ternaryfunc)0,  /*tp_call*/
-    (reprfunc)0,  /*tp_str*/
-    (getattrofunc)path_getattro, /* tp_getattro */
 };
-#else
-static PyObject* path_getattr(PathObject* self, char* name);
-static PyTypeObject PathType = {
-    PyObject_HEAD_INIT(NULL)
-    0, "Path", sizeof(PathObject), 0,
-    /* methods */
-    (destructor) path_dealloc, /* tp_dealloc */
-    0, /* tp_print */
-    (getattrfunc) path_getattr, /* tp_getattr */
-    0, /* tp_setattr */
-};
-#endif
 
 #define Path_Check(op) ((op) != NULL && Py_TYPE(op) == &PathType)
 
@@ -328,22 +238,12 @@ static agg::rgba8 getcolor(PyObject* color, int opacity=255);
 static int
 text_getchar(PyObject* string, int index, unsigned long* char_out)
 {
-#if defined(HAVE_UNICODE)
     if (PyUnicode_Check(string)) {
         Py_ssize_t str_len = PyUnicode_GetLength(string);
         if (index >= str_len)
             return 0;
         Py_UCS4 this_char = PyUnicode_READ_CHAR(string, index);
         *char_out = this_char;
-        return 1;
-    }
-#endif
-    if (PyBytes_Check(string)) {
-        unsigned char* p = (unsigned char*) PyBytes_AS_STRING(string);
-        int size = PyBytes_GET_SIZE(string);
-        if (index >= size)
-            return 0;
-        *char_out = (unsigned char) p[index];
         return 1;
     }
     return 0;
@@ -612,11 +512,7 @@ draw_new(PyObject* self_, PyObject* args)
         PyObject* mode_obj = PyObject_GetAttrString(image, "mode");
         if (!mode_obj)
             return NULL;
-        if (PyBytes_Check(mode_obj)) {
-            strncpy(buffer, PyBytes_AS_STRING(mode_obj), sizeof buffer);
-            buffer[sizeof(buffer)-1] = '\0'; /* to be on the safe side */
-            mode = buffer;
-        } else if (PyUnicode_Check(mode_obj)) {
+        if (PyUnicode_Check(mode_obj)) {
             PyObject* ascii_mode = PyUnicode_AsASCIIString(mode_obj);
             if (ascii_mode == NULL) {
                 mode = NULL;
@@ -740,17 +636,10 @@ struct PointF {
     float Y;
 };
 
-#ifdef IS_PY3K
 #define GETFLOAT(op)                                    \
     (PyLong_Check(op) ? (float) PyLong_AS_LONG((op)) :\
      PyFloat_Check(op) ? (float) PyFloat_AS_DOUBLE((op)) :\
      (float) PyFloat_AsDouble(op))
-#else
-#define GETFLOAT(op)                                    \
-    (PyInt_Check(op) ? (float) PyInt_AS_LONG((op)) :\
-     PyFloat_Check(op) ? (float) PyFloat_AS_DOUBLE((op)) :\
-     (float) PyFloat_AsDouble(op))
-#endif
 
 static PointF*
 getpoints(PyObject* xyIn, int* count)
@@ -816,31 +705,26 @@ getpoints(PyObject* xyIn, int* count)
 static agg::rgba8
 getcolor(PyObject* color, int opacity)
 {
-#ifdef IS_PY3K
     if (PyLong_Check(color)) {
         int ink = PyLong_AsLong(color);
         return agg::rgba8(ink, ink, ink, opacity);
     }
-#else
-    if (PyInt_Check(color)) {
-        int ink = PyInt_AsLong(color);
-        return agg::rgba8(ink, ink, ink, opacity);
-    }
-#endif
+
     char buffer[10];
     char* ink = NULL;
     if (PyUnicode_Check(color)) {
         PyObject* ascii_color = PyUnicode_AsASCIIString(color);
         if (ascii_color == NULL) {
-            ink = NULL;
+            /* not ASCII: leave ink NULL and let the lookups below fall
+               through to black. Clear the error so that the calls that
+               follow do not run with a live exception set. */
+            PyErr_Clear();
         } else {
             strncpy(buffer, PyBytes_AsString(ascii_color), sizeof buffer);
             buffer[sizeof(buffer)-1] = '\0'; /* to be on the safe side */
             ink = buffer;
             Py_XDECREF(ascii_color);
         }
-    } else if (PyBytes_Check(color)) {
-        ink = PyBytes_AsString(color);
     }
     /* hex colors */
     if (ink && ink[0] == '#' && strlen(ink) == 7) {
@@ -865,7 +749,7 @@ getcolor(PyObject* color, int opacity)
         PyErr_Clear();
     }
     /* check for well-known color names (HTML) */
-    if (PyUnicode_Check(color) || PyBytes_Check(color)) {
+    if (ink) {
         if (!strcmp(ink, "aqua"))
             return agg::rgba8(0x00,0xFF,0xFF,opacity);
         if (!strcmp(ink, "black"))
@@ -1643,8 +1527,6 @@ static PyMethodDef draw_methods[] = {
     {NULL, NULL}
 };
 
-#ifdef IS_PY3K
-
 static PyObject*
 draw_getattro(DrawObject* self, PyObject* nameobj)
 {
@@ -1660,22 +1542,6 @@ draw_getattro(DrawObject* self, PyObject* nameobj)
   generic:
     return PyObject_GenericGetAttr((PyObject*)self, nameobj);
 }
-
-#else
-
-static PyObject*
-draw_getattr(DrawObject* self, char* name)
-{
-    if (!strcmp(name, "mode"))
-        return PyBytes_FromString(self->draw->mode);
-    if (!strcmp(name, "size"))
-        return Py_BuildValue(
-            "(ii)", self->buffer->width(), self->buffer->height()
-            );
-    return Py_FindMethod(draw_methods, (PyObject*) self, name);
-}
-
-#endif
 
 /* -------------------------------------------------------------------- */
 
@@ -1851,7 +1717,6 @@ font_load(FontObject* font, bool outline)
 }
 #endif
 
-#ifdef IS_PY3K
 static PyObject*
 font_getattro(FontObject* self, PyObject* nameobj)
 {
@@ -1867,7 +1732,7 @@ font_getattro(FontObject* self, PyObject* nameobj)
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return PyBytes_FromString(face->family_name);
+        return PyUnicode_FromString(face->family_name);
     }
     if (PyUnicode_CompareWithASCIIString(nameobj, "style") == 0)
     {
@@ -1876,7 +1741,7 @@ font_getattro(FontObject* self, PyObject* nameobj)
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return PyBytes_FromString(face->style_name);
+        return PyUnicode_FromString(face->style_name);
     }
     if (PyUnicode_CompareWithASCIIString(nameobj, "ascent") == 0)
     {
@@ -1900,49 +1765,6 @@ font_getattro(FontObject* self, PyObject* nameobj)
   generic:
     return PyObject_GenericGetAttr((PyObject*)self, nameobj);
 }
-
-#else
-static PyObject*
-font_getattr(FontObject* self, char* name)
-{
-#if defined(HAVE_FREETYPE2)
-    FT_Face face;
-    if (!strcmp(name, "family")) {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyBytes_FromString(face->family_name);
-    }
-    if (!strcmp(name, "style")) {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyBytes_FromString(face->style_name);
-    }
-    if (!strcmp(name, "ascent")) {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyFloat_FromDouble(face->size->metrics.ascender/64.0);
-    }
-    if (!strcmp(name, "descent")) {
-        face = font_load(self);
-        if (!face) {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
-        return PyFloat_FromDouble(-face->size->metrics.descender/64.0);
-    }
-#endif
-    return Py_FindMethod(font_methods, (PyObject*) self, name);
-}
-#endif
 
 static void
 font_dealloc(FontObject* self)
@@ -2458,21 +2280,6 @@ static PyMethodDef path_methods[] = {
     {NULL, NULL}
 };
 
-#ifdef IS_PY3K
-static PyObject*
-path_getattro(PathObject* self, PyObject* nameobj)
-{
-    return PyObject_GenericGetAttr((PyObject*)self, nameobj);
-}
-
-#else
-static PyObject*
-path_getattr(PathObject* self, char* name)
-{
-    return Py_FindMethod(path_methods, (PyObject*) self, name);
-}
-#endif
-
 /* -------------------------------------------------------------------- */
 
 static PyMethodDef aggdraw_functions[] = {
@@ -2509,7 +2316,6 @@ const char *mod_doc = "Python interface to the Anti-Grain Graphics Drawing libra
                       "    >>> d.line((0, 500, 500, 0), p)\n"
                       "    >>> s = d.tobytes()\n";
 
-#ifdef IS_PY3K
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_aggdraw",
@@ -2521,40 +2327,58 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL,
 };
-#endif
 
 
 static PyObject *
 aggdraw_init(void)
 {
-#ifdef IS_PY3K
-    // PyType_Ready(&DrawType);
-    // PyType_Ready(&PathType);
-    // PyType_Ready(&PenType);
-    // PyType_Ready(&BrushType);
-    // PyType_Ready(&FontType);
-
+    /* tp_methods must be assigned before PyType_Ready: PyType_Ready copies
+       tp_methods into tp_dict once and never looks at it again. (The arrays
+       are defined further down the file, and C++ has no tentative
+       definitions, so they cannot be named from the static initializers.)
+       Pen and Brush expose no methods. */
     DrawType.tp_methods = draw_methods;
     FontType.tp_methods = font_methods;
     PathType.tp_methods = path_methods;
 
-    PyObject *module = PyModule_Create(&moduledef);
-    PyObject *version = PyUnicode_FromString(QUOTE(VERSION));
-    PyObject_SetAttrString(module, "VERSION", version);
-    PyObject_SetAttrString(module, "__version__", version);
-    Py_DECREF(version);
-#else
-    DrawType.ob_type = PathType.ob_type = &PyType_Type;
-    PenType.ob_type = BrushType.ob_type = FontType.ob_type = &PyType_Type;
+    DrawType.tp_flags = Py_TPFLAGS_DEFAULT;
+    PenType.tp_flags = Py_TPFLAGS_DEFAULT;
+    BrushType.tp_flags = Py_TPFLAGS_DEFAULT;
+    FontType.tp_flags = Py_TPFLAGS_DEFAULT;
+    PathType.tp_flags = Py_TPFLAGS_DEFAULT;
 
-    PyObject *module = Py_InitModule3("aggdraw", aggdraw_functions, mod_doc);
-    PyObject *version = PyBytes_FromString(QUOTE(VERSION));
-    PyObject_SetAttrString(module, "VERSION", version);
-    PyObject_SetAttrString(module, "__version__", version);
-    Py_DECREF(version);
-#endif
+    /* Without this the types keep a NULL ob_type and type(obj) crashes.
+       Note: Py_TPFLAGS_BASETYPE is deliberately NOT set -- the deallocators
+       call PyObject_DEL directly rather than going through tp_free, which is
+       only safe as long as these types cannot be subclassed. */
+    if (PyType_Ready(&DrawType) < 0)
+        return NULL;
+    if (PyType_Ready(&PenType) < 0)
+        return NULL;
+    if (PyType_Ready(&BrushType) < 0)
+        return NULL;
+    if (PyType_Ready(&FontType) < 0)
+        return NULL;
+    if (PyType_Ready(&PathType) < 0)
+        return NULL;
+
+    PyObject *module = PyModule_Create(&moduledef);
     if (module == NULL)
         return NULL;
+
+    PyObject *version = PyUnicode_FromString(QUOTE(VERSION));
+    if (version == NULL) {
+        Py_DECREF(module);
+        return NULL;
+    }
+    int rc = PyObject_SetAttrString(module, "VERSION", version);
+    if (rc == 0)
+        rc = PyObject_SetAttrString(module, "__version__", version);
+    Py_DECREF(version);
+    if (rc < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
 
     PyObject* g = PyDict_New();
     PyDict_SetItemString(g, "__builtins__", PyEval_GetBuiltins());
@@ -2571,6 +2395,10 @@ aggdraw_init(void)
 
         );
 
+    /* Borrowed reference. `g` is deliberately leaked: it is what keeps
+       aggdraw_getcolor_obj alive for the lifetime of the module. Do not
+       "tidy up" with Py_DECREF(g) -- that turns every getcolor() call into
+       a use-after-free. */
     aggdraw_getcolor_obj = PyDict_GetItemString(g, "getcolor");
 
 #ifdef Py_GIL_DISABLED
@@ -2580,17 +2408,8 @@ aggdraw_init(void)
     return module;
 }
 
-#ifdef IS_PY3K
 PyMODINIT_FUNC
 PyInit__aggdraw(void)
 {
     return aggdraw_init();
 }
-
-#else
-PyMODINIT_FUNC
-initaggdraw(void)
-{
-    aggdraw_init();
-}
-#endif

--- a/aggdraw/core.py
+++ b/aggdraw/core.py
@@ -1,3 +1,5 @@
+import warnings
+
 import aggdraw._aggdraw as _aggdraw
 
 
@@ -163,37 +165,6 @@ class Font:
         return self._font.descent
 
 
-class Symbol:
-    """Symbol factory.
-
-    This creates a symbol object from an SVG-style path descriptor for use with
-    :meth:`~aggdraw.Draw.symbol`.
-
-    The following operators are supported:
-     * M (move)
-     * L (line)
-     * H (horizontal line)
-     * V (vertical line)
-     * C (cubic bezier)
-     * S (smooth cubic bezier)
-     * Q (quadratic bezier)
-     * T (smooth quadratic bezier)
-     * Z (close path)
-
-    Use lower-case operators for relative coordinates, upper-case for absolute
-    coordinates.
-
-    Args:
-        path (str): An SVG-style path descriptor.
-        scale (float, optional): A multiplier applied to every coordinate in the
-            path descriptor as it is parsed. Defaults to 1.0.
-
-    """
-
-    def __init__(self, path, scale=1.0):
-        self._path = _aggdraw.Symbol(path, scale)
-
-
 class Path:
     """Path factory.
 
@@ -215,6 +186,58 @@ class Path:
             self._path = _aggdraw.Path(path)
         else:
             self._path = _aggdraw.Path()
+
+    # Deliberately out of the otherwise-alphabetical method order: an alternate
+    # constructor belongs at the top, and autodoc_member_order is "bysource".
+    @classmethod
+    def from_svg(cls, path, scale=1.0):
+        """Creates a path from an SVG-style path descriptor.
+
+        The following operators are supported:
+         * M (move)
+         * L (line)
+         * H (horizontal line)
+         * V (vertical line)
+         * C (cubic bezier)
+         * S (smooth cubic bezier)
+         * Q (quadratic bezier)
+         * T (smooth quadratic bezier)
+         * Z (close path)
+
+        Use lower-case operators for relative coordinates, upper-case for
+        absolute coordinates. Curves are flattened to line segments as the
+        descriptor is parsed, so :meth:`~aggdraw.Path.coords` on the result
+        returns the flattened geometry.
+
+        The returned path is an ordinary path: it can be extended with
+        :meth:`~aggdraw.Path.lineto` and the other segment methods, and drawn
+        with either :meth:`~aggdraw.Draw.path` or :meth:`~aggdraw.Draw.symbol`.
+
+        Example::
+
+           path = aggdraw.Path.from_svg("M400,200 L400,400")
+
+        This is a classmethod, so calling it on a subclass returns an instance
+        of that subclass. It builds the object directly and does not call
+        ``__init__``.
+
+        .. versionadded:: 2.0.0
+
+        Args:
+            path (str): An SVG-style path descriptor.
+            scale (float, optional): A multiplier applied to every coordinate in
+                the path descriptor as it is parsed. Defaults to 1.0.
+
+        Returns:
+            :class:`aggdraw.Path`: A new path, of the class this was called on.
+
+        Raises:
+            ValueError: If the descriptor cannot be parsed.
+
+        """
+        new_path = cls.__new__(cls)
+        new_path._path = _aggdraw.Path.from_svg(path, scale)
+        return new_path
 
     def close(self):
         """Closes the current path.
@@ -324,6 +347,43 @@ class Path:
 
         """
         self._path.rmoveto(x, y)
+
+
+class Symbol(Path):
+    """A path created from an SVG-style path descriptor.
+
+    .. deprecated:: 2.0.0
+       Use :meth:`aggdraw.Path.from_svg` instead. Constructing a ``Symbol``
+       emits a :exc:`UserWarning`. A ``Symbol`` is now a subclass of
+       :class:`aggdraw.Path` that adds no state and no methods of its own, so
+       existing symbols keep working everywhere a path does. See
+       `issue #145 <https://github.com/pytroll/aggdraw/issues/145>`_.
+
+    Args:
+        path (str): An SVG-style path descriptor. See
+            :meth:`~aggdraw.Path.from_svg` for the supported operators.
+        scale (float, optional): A multiplier applied to every coordinate in the
+            path descriptor as it is parsed. Defaults to 1.0.
+
+    """
+
+    # The warning lives in __new__ rather than __init__ so that the inherited
+    # Path.from_svg -- which calls cls.__new__ and skips __init__ -- warns too.
+    def __new__(cls, *args, **kwargs):
+        warnings.warn(
+            "aggdraw.Symbol is deprecated and will be removed in a future "
+            "release; use aggdraw.Path.from_svg(path, scale) instead. "
+            "See https://github.com/pytroll/aggdraw/issues/145",
+            UserWarning,
+            stacklevel=2,
+        )
+        return super().__new__(cls)
+
+    def __init__(self, path, scale=1.0):
+        # Deliberately does not call Path.__init__: the C constructor parses the
+        # descriptor and builds the path itself, so super() would only allocate
+        # an empty _aggdraw.Path and throw it away.
+        self._path = _aggdraw.Symbol(path, scale)
 
 
 class Draw:
@@ -477,7 +537,7 @@ class Draw:
         specific location on the surface, see :meth:`~aggdraw.Draw.symbol`.
 
         Args:
-            path (:class:`aggdraw.Path`): The Path object to draw.
+            path (:class:`aggdraw.Path`): The path to draw.
             pen (:class:`aggdraw.Pen`, optional): A pen to use for drawing an outline
                 around the path.
             brush (:class:`aggdraw.Brush`, optional): A brush to use for filling
@@ -611,13 +671,13 @@ class Draw:
         it is used to draw an outline around the symbol. Either one (or both)
         can be left out.
 
-        This method can be used to draw both :class:`aggdraw.Symbol` or
-        :class:`aggdraw.Path` objects.
+        This stamps a copy of the path at every position in ``xy``, whereas
+        :meth:`~aggdraw.Draw.path` draws it once at the coordinates it was
+        defined with. Any :class:`aggdraw.Path` can be drawn this way.
 
         Args:
             xy: A Python sequence in the format (x, y, x, y, ...)
-            symbol (:class:`aggdraw.Symbol`, :class:`aggdraw.Path`): The Symbol (or
-                Path) object to draw.
+            symbol (:class:`aggdraw.Path`): The path to stamp at each position.
             pen (:class:`aggdraw.Pen`, optional): A pen to use for drawing an outline
                 around the symbol.
             brush (:class:`aggdraw.Brush`, optional): A brush to use for filling

--- a/aggdraw/core.py
+++ b/aggdraw/core.py
@@ -317,9 +317,9 @@ class Draw:
         return self._draw.mode
 
     def _parse_args(self, brush=None, pen=None):
-        # Allow order of brush and pen to be reversed, matching C++ API
-        # NOTE: This segfaults for some reason if pen and brush are swapped here
-        # instead of leaving it to the C++ extension to handle
+        # Allow order of brush and pen to be reversed, matching C++ API.
+        # The C dispatcher picks pen and brush by type, not by position, so
+        # this only has to unwrap whichever object it was actually handed.
         if brush:
             brush = brush._pen if isinstance(brush, Pen) else brush._brush
         if pen:

--- a/aggdraw/core.py
+++ b/aggdraw/core.py
@@ -34,6 +34,16 @@ class Brush:
     def __init__(self, color, opacity=255):
         self._brush = _aggdraw.Brush(color, opacity)
 
+    @property
+    def color(self):
+        """tuple: The resolved brush color as ``(R, G, B, A)``.
+
+        This is the color after parsing, so a color that could not be
+        recognized reads back as black.
+
+        """
+        return self._brush.color
+
 
 class Pen:
     """Creates a pen object.
@@ -80,6 +90,21 @@ class Pen:
     def __init__(self, color, width=1, opacity=255):
         self._pen = _aggdraw.Pen(color, width, opacity)
 
+    @property
+    def color(self):
+        """tuple: The resolved pen color as ``(R, G, B, A)``.
+
+        This is the color after parsing, so a color that could not be
+        recognized reads back as black.
+
+        """
+        return self._pen.color
+
+    @property
+    def width(self):
+        """float: The width of the pen."""
+        return self._pen.width
+
 
 class Font:
     """Creates a font object.
@@ -116,6 +141,26 @@ class Font:
     def __init__(self, color, file, size=12, opacity=255):
         # NOTE: Only available if compiled with FreeType support
         self._font = _aggdraw.Font(color, file, size, opacity)
+
+    @property
+    def family(self):
+        """str: The font family name reported by FreeType."""
+        return self._font.family
+
+    @property
+    def style(self):
+        """str: The font style name reported by FreeType."""
+        return self._font.style
+
+    @property
+    def ascent(self):
+        """float: The font ascent, in pixels."""
+        return self._font.ascent
+
+    @property
+    def descent(self):
+        """float: The font descent, in pixels, as a positive number."""
+        return self._font.descent
 
 
 class Symbol:

--- a/aggdraw/tests/_helpers.py
+++ b/aggdraw/tests/_helpers.py
@@ -3,6 +3,8 @@
 import numpy as np
 from PIL import Image
 
+import aggdraw
+
 
 WHITE = (255, 255, 255)
 
@@ -26,3 +28,28 @@ def ink_count(im):
     if im.mode != "RGB":
         raise NotImplementedError(f"ink_count only supports RGB images, got {im.mode!r}")
     return int(np.any(np.asarray(im) != WHITE, axis=-1).sum())
+
+
+def render(path):
+    """Draw a path in black on a white 100x100 surface.
+
+    Drawing black on white means any pixel that isn't WHITE is part of the
+    path. Antialiasing makes the edges gray rather than pure black, so tests
+    check for "not the background" instead of for an exact ink color.
+    """
+    return draw_with("path", path, aggdraw.Pen("black", 1))
+
+
+def draw_with(method, path, pen=None):
+    """Draw a path on a fresh white surface with one of the Draw methods.
+
+    ``symbol`` takes a position as well; (0, 0) draws the path where it was
+    defined, matching what the other methods do. A pen of None is passed
+    through as-is, so nothing is drawn -- the same as calling Draw directly.
+    """
+    draw = aggdraw.Draw("RGB", (100, 100), "white")
+    if method == "symbol":
+        draw.symbol((0, 0), path, pen)
+    else:
+        getattr(draw, method)(path, pen)
+    return to_image(draw)

--- a/aggdraw/tests/test_brush.py
+++ b/aggdraw/tests/test_brush.py
@@ -68,3 +68,12 @@ def test_brush_rgba_tuple_overrides_opacity():
     # ...while a 4-tuple sets it directly, ignoring opacity entirely
     assert _fill((255, 0, 0, 128)) == half_red
     assert _fill((255, 0, 0, 255), opacity=128) == (255, 0, 0)
+
+
+def test_brush_exposes_color():
+    """Brush.color reports the resolved color, including opacity."""
+    from aggdraw import Brush
+
+    assert Brush("blue").color == (0, 0, 255, 255)
+    assert Brush("blue", 128).color == (0, 0, 255, 128)
+    assert Brush("not a color").color == (0, 0, 0, 255)

--- a/aggdraw/tests/test_draw.py
+++ b/aggdraw/tests/test_draw.py
@@ -117,3 +117,23 @@ def test_draw_type_is_readable():
     from aggdraw import Draw
 
     assert type(Draw("RGB", (10, 10), "white")._draw).__name__ == "Draw"
+
+
+def test_draw_rejects_keyword_arguments():
+    """Draw() and Path() take no keyword arguments.
+
+    They are tp_new slots now, and tp_new is handed keywords whether or not it
+    wants them; without an explicit check they would be silently ignored.
+    """
+    import pytest
+
+    from aggdraw import _aggdraw
+
+    with pytest.raises(TypeError, match="no keyword arguments"):
+        _aggdraw.Draw("RGB", (4, 4), color="red")
+    with pytest.raises(TypeError, match="no keyword arguments"):
+        _aggdraw.Path([0, 0, 1, 1], bogus=1)
+
+    # the keyword-accepting constructors are unaffected
+    assert _aggdraw.Pen(color="red", width=2).width == 2.0
+    assert _aggdraw.Brush(color="red", opacity=128).color == (255, 0, 0, 128)

--- a/aggdraw/tests/test_draw.py
+++ b/aggdraw/tests/test_draw.py
@@ -106,3 +106,14 @@ def test_polygon_closes_coords_but_not_path():
     filled_coords = polygon(corner, brush=brush)
     filled_path = polygon(open_path, brush=brush)
     assert filled_coords.tobytes() == filled_path.tobytes()
+
+
+def test_draw_type_is_readable():
+    """type() on the underlying C Draw object must not crash.
+
+    The C type objects are only given an ob_type by PyType_Ready, which the
+    module init used to skip entirely.
+    """
+    from aggdraw import Draw
+
+    assert type(Draw("RGB", (10, 10), "white")._draw).__name__ == "Draw"

--- a/aggdraw/tests/test_draw.py
+++ b/aggdraw/tests/test_draw.py
@@ -108,6 +108,24 @@ def test_polygon_closes_coords_but_not_path():
     assert filled_coords.tobytes() == filled_path.tobytes()
 
 
+def test_symbol_stamps_a_path_at_every_position():
+    """Draw.symbol translates a copy of the path to each point in xy.
+
+    This is the only thing that distinguishes it from Draw.path, which draws
+    the path once at the coordinates it was defined with.
+    """
+    path = aggdraw.Path.from_svg("M0,0 L20,0 L20,20 Z")
+    draw = aggdraw.Draw("RGB", (100, 100), "white")
+    draw.symbol((10, 10, 60, 60), path, aggdraw.Pen("black", 1))
+    im = to_image(draw)
+
+    # A copy lands at each position...
+    assert im.getpixel((20, 10)) != WHITE
+    assert im.getpixel((70, 60)) != WHITE
+    # ...and the gap between them is left alone
+    assert im.getpixel((45, 40)) == WHITE
+
+
 def test_draw_type_is_readable():
     """type() on the underlying C Draw object must not crash.
 

--- a/aggdraw/tests/test_font.py
+++ b/aggdraw/tests/test_font.py
@@ -1,0 +1,78 @@
+"""Tests for the Font class."""
+
+import glob
+import os
+
+import pytest
+
+import aggdraw
+from aggdraw.tests._helpers import WHITE, ink_count, to_image
+
+
+FONT_DIRS = [
+    "/usr/share/fonts",  # linux
+    "/usr/local/share/fonts",  # linux
+    "/System/Library/Fonts",  # macos
+    "/Library/Fonts",  # macos
+    os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "Fonts"),  # windows
+]
+
+
+def _find_font():
+    """Return the path of any TrueType font on this machine, or None.
+
+    aggdraw ships no font of its own and Pillow's default font is not a file
+    on disk, so there is nothing portable to point Font() at.
+    """
+    for directory in FONT_DIRS:
+        matches = sorted(glob.glob(os.path.join(directory, "**", "*.ttf"), recursive=True))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _font_or_skip(color="black", size=12):
+    """Build a Font, skipping the test if fonts or FreeType are unavailable."""
+    if not hasattr(aggdraw.Draw("RGB", (1, 1), "white")._draw, "text"):
+        pytest.skip("built without FreeType, so there is no text renderer")
+    path = _find_font()
+    if path is None:
+        pytest.skip("no TrueType font found on this machine")
+    return aggdraw.Font(color, path, size)
+
+
+def test_font_metrics_are_str():
+    """family and style are str, not bytes.
+
+    They used to be built with PyBytes_FromString, a leftover from Python 2
+    where that produced a str.
+    """
+    # these attributes are only exposed on the underlying C object
+    cfont = _font_or_skip("black")._font
+
+    assert isinstance(cfont.family, str)
+    assert isinstance(cfont.style, str)
+    assert cfont.family
+    assert isinstance(cfont.ascent, float)
+    assert isinstance(cfont.descent, float)
+
+
+def test_font_draws_text():
+    """Text actually puts ink on the surface, in the requested color."""
+    font = _font_or_skip("red", 24)
+
+    surf = aggdraw.Draw("RGB", (200, 60), "white")
+    width, height = surf.textsize("Hello", font)
+    assert width > 0
+    assert height > 0
+
+    surf.text((5, 5), "Hello", font)
+    im = to_image(surf)
+    assert ink_count(im) > 0
+    # every inked pixel is some blend of red over white
+    for x in range(im.width):
+        for y in range(im.height):
+            r, g, b = im.getpixel((x, y))
+            if (r, g, b) != WHITE:
+                assert g == b
+                assert r >= g

--- a/aggdraw/tests/test_font.py
+++ b/aggdraw/tests/test_font.py
@@ -18,16 +18,33 @@ FONT_DIRS = [
 ]
 
 
+# Fonts known to carry Latin glyphs, most preferred first. Taking the first .ttf in
+# Other available fonts may not have expected glyph shapes/sizes so would fail tests.
+PREFERRED_FONTS = (
+    "DejaVuSans.ttf",  # most linux distros, conda envs
+    "LiberationSans-Regular.ttf",  # fedora/rhel, ubuntu
+    "FreeSans.ttf",  # gnu freefont
+    "NotoSans-Regular.ttf",
+    "Arial.ttf",  # macos /System/Library/Fonts/Supplemental, msttcorefonts
+    "arial.ttf",  # windows
+    "Verdana.ttf",
+    "verdana.ttf",
+)
+
+
 def _find_font():
-    """Return the path of any TrueType font on this machine, or None.
+    """Return the path of a TrueType font with Latin glyphs, or None.
 
     aggdraw ships no font of its own and Pillow's default font is not a file
     on disk, so there is nothing portable to point Font() at.
     """
+    found = {}
     for directory in FONT_DIRS:
-        matches = sorted(glob.glob(os.path.join(directory, "**", "*.ttf"), recursive=True))
-        if matches:
-            return matches[0]
+        for path in glob.glob(os.path.join(directory, "**", "*.ttf"), recursive=True):
+            found.setdefault(os.path.basename(path), path)
+    for name in PREFERRED_FONTS:
+        if name in found:
+            return found[name]
     return None
 
 
@@ -37,7 +54,7 @@ def _font_or_skip(color="black", size=12):
         pytest.skip("built without FreeType, so there is no text renderer")
     path = _find_font()
     if path is None:
-        pytest.skip("no TrueType font found on this machine")
+        pytest.skip("no suitable TrueType font found on this machine")
     return aggdraw.Font(color, path, size)
 
 

--- a/aggdraw/tests/test_font.py
+++ b/aggdraw/tests/test_font.py
@@ -3,10 +3,11 @@
 import glob
 import os
 
+import numpy as np
 import pytest
 
 import aggdraw
-from aggdraw.tests._helpers import WHITE, ink_count, to_image
+from aggdraw.tests._helpers import WHITE, to_image
 
 
 FONT_DIRS = [
@@ -85,12 +86,12 @@ def test_font_draws_text():
     assert height > 0
 
     surf.text((5, 5), "Hello", font)
-    im = to_image(surf)
-    assert ink_count(im) > 0
-    # every inked pixel is some blend of red over white
-    for x in range(im.width):
-        for y in range(im.height):
-            r, g, b = im.getpixel((x, y))
-            if (r, g, b) != WHITE:
-                assert g == b
-                assert r >= g
+    arr = np.asarray(to_image(surf))
+    ink = arr[np.any(arr != WHITE, axis=-1)]
+
+    # were any red pixels drawn?
+    assert np.any(np.all(ink == (255, 0, 0), axis=-1))
+    # AGG blends coverage over the background, so red over white is always
+    # (255, 255 - k, 255 - k): the red channel saturates and green tracks blue
+    assert np.all(ink[:, 0] == 255)
+    assert np.all(ink[:, 1] == ink[:, 2])

--- a/aggdraw/tests/test_font.py
+++ b/aggdraw/tests/test_font.py
@@ -47,14 +47,15 @@ def test_font_metrics_are_str():
     They used to be built with PyBytes_FromString, a leftover from Python 2
     where that produced a str.
     """
-    # these attributes are only exposed on the underlying C object
-    cfont = _font_or_skip("black")._font
+    font = _font_or_skip("black")
 
-    assert isinstance(cfont.family, str)
-    assert isinstance(cfont.style, str)
-    assert cfont.family
-    assert isinstance(cfont.ascent, float)
-    assert isinstance(cfont.descent, float)
+    assert isinstance(font.family, str)
+    assert isinstance(font.style, str)
+    assert font.family
+    assert isinstance(font.ascent, float)
+    assert isinstance(font.descent, float)
+    # the wrapper forwards to the same values on the C object
+    assert font.family == font._font.family
 
 
 def test_font_draws_text():

--- a/aggdraw/tests/test_path.py
+++ b/aggdraw/tests/test_path.py
@@ -5,10 +5,23 @@ import sys
 import aggdraw
 import pytest
 
-from aggdraw.tests._helpers import WHITE, ink_count, to_image
+from aggdraw import _aggdraw
+from aggdraw.tests._helpers import WHITE, draw_with, ink_count, render
 
 # The Draw methods that accept a Path
 DRAW_METHODS = ["line", "polygon", "symbol", "path"]
+
+# One descriptor per operator the SVG parser supports, in both the absolute and
+# the relative spelling, with the coordinates the parser should produce. All of
+# them start at (10, 10) so the relative and absolute forms are comparable.
+SVG_OPERATORS = [
+    ("M10,10 L20,20", [10, 10, 20, 20]),
+    ("m10,10 l10,10", [10, 10, 20, 20]),
+    ("M10,10 H20", [10, 10, 20, 10]),
+    ("m10,10 h10", [10, 10, 20, 10]),
+    ("M10,10 V20", [10, 10, 10, 20]),
+    ("m10,10 v10", [10, 10, 10, 20]),
+]
 
 
 def test_path_init():
@@ -44,7 +57,7 @@ def test_path_close_connects_to_subpath_start():
     (10, 90) back up to (90, 20), the start of that second subpath, rather
     than a vertical edge back to (10, 10) where the path itself began.
 
-    Rendered by :func:`_render`, so the background is white and the path is
+    Rendered by :func:`render`, so the background is white and the path is
     drawn in black: a pixel equal to WHITE is blank and anything else is ink.
     """
 
@@ -59,8 +72,8 @@ def test_path_close_connects_to_subpath_start():
             p.close()
         return p
 
-    before = _render(build(False))
-    after = _render(build(True))
+    before = render(build(False))
+    after = render(build(True))
     # Points along the expected diagonal are blank until the path is closed
     for x, y in [(21, 80), (44, 60), (67, 40)]:
         assert before.getpixel((x, y)) == WHITE
@@ -78,13 +91,13 @@ def test_path_close_erases_degenerate_subpath():
     # already added by lineto with it. This is a "bug" in upstream AGG C++.
     p = aggdraw.Path([10.0, 10.0, 90.0, 10.0])
     coords = p.coords()
-    assert ink_count(_render(p)) > 0
+    assert ink_count(render(p)) > 0
 
     p.close()
     # close() sets a flag rather than appending a vertex, so the coordinates
     # are unchanged and only the rendered pixels reveal what happened
     assert p.coords() == coords
-    assert ink_count(_render(p)) == 0
+    assert ink_count(render(p)) == 0
 
 
 def test_path_curveto():
@@ -148,9 +161,102 @@ def test_path_rmoveto():
     assert pts == [10, 10, 20, 20, 15, 25, 25, 35]
 
 
+@pytest.mark.parametrize(("descriptor", "expected"), SVG_OPERATORS)
+def test_path_from_svg_operators(descriptor, expected):
+    # Each operator produces the coordinates it says it does, and the relative
+    # (lower-case) spelling matches the absolute one.
+    assert aggdraw.Path.from_svg(descriptor).coords() == expected
+
+
+def test_path_from_svg_matches_manual_path():
+    # A descriptor and the equivalent hand-built path are the same path, both
+    # in coordinates and in the pixels they paint.
+    from_svg = aggdraw.Path.from_svg("M10,10 L90,10 L90,90 Z")
+    manual = aggdraw.Path()
+    manual.moveto(10, 10)
+    manual.lineto(90, 10)
+    manual.lineto(90, 90)
+    manual.close()
+
+    assert from_svg.coords() == manual.coords()
+    assert render(from_svg).tobytes() == render(manual).tobytes()
+
+
+def test_path_from_svg_curves_are_flattened():
+    # Curves are expanded to line segments while parsing, so coords() returns
+    # more points than the descriptor names.
+    p = aggdraw.Path.from_svg("M10,10 C20,20 30,20 40,10")
+    pts = p.coords()
+    assert len(pts) > 8
+    assert pts[:2] == [10, 10]
+    assert pts[-2:] == [40, 10]
+
+
+def test_path_from_svg_scale():
+    # scale multiplies every coordinate as the descriptor is parsed.
+    assert aggdraw.Path.from_svg("M10,10 L20,10", 2).coords() == [20, 20, 40, 20]
+    # ...and it is applied before rendering, not after, so a scaled path paints
+    # the same pixels as the equivalent unscaled one.
+    scaled = aggdraw.Path.from_svg("M5,5 L45,5 L45,45 Z", 2)
+    manual = aggdraw.Path.from_svg("M10,10 L90,10 L90,90 Z")
+    assert render(scaled).tobytes() == render(manual).tobytes()
+
+
+def test_path_from_svg_returns_a_usable_path():
+    # The result is an ordinary Path, not an opaque handle: it can be extended
+    # and the extension is drawn.
+    p = aggdraw.Path.from_svg("M10,10 L90,10")
+    before = ink_count(render(p))
+    p.lineto(90, 90)
+    assert p.coords() == [10, 10, 90, 10, 90, 90]
+    assert ink_count(render(p)) > before
+
+
+def test_path_from_svg_does_not_warn(recwarn):
+    # Only the deprecated Symbol spelling warns; the replacement must not.
+    aggdraw.Path.from_svg("M0,0 L10,10")
+    assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "message"),
+    [
+        ("0,0", "no command at start of path"),
+        ("A10,10", "unknown path command 'A'"),
+        ("M-", "invalid arguments for command 'M'"),
+    ],
+)
+def test_path_from_svg_invalid_descriptor(descriptor, message):
+    with pytest.raises(ValueError, match=message):
+        aggdraw.Path.from_svg(descriptor)
+
+
+def test_path_from_svg_on_a_subclass():
+    # from_svg is a classmethod, so it builds an instance of whatever class it
+    # was called on -- at both layers.
+    class MyPath(aggdraw.Path):
+        pass
+
+    assert type(MyPath.from_svg("M0,0 L1,1")) is MyPath
+
+    class MyCPath(_aggdraw.Path):
+        pass
+
+    assert type(MyCPath.from_svg("M0,0 L1,1")) is MyCPath
+    # The deprecated C Symbol type inherits it too, and stays a Symbol.
+    assert type(_aggdraw.Symbol.from_svg("M0,0 L1,1")) is _aggdraw.Symbol
+
+
+def test_path_from_svg_rejects_a_foreign_class():
+    # The classmethod descriptor guards this for us; check it really does,
+    # since path_from_svg_impl allocates from whatever it is handed.
+    with pytest.raises(TypeError, match="requires a subtype"):
+        _aggdraw.Path.__dict__["from_svg"].__get__(None, int)
+
+
 @pytest.mark.parametrize("method", DRAW_METHODS)
 def test_path_draw(method):
-    im = _draw_with(method, _sample_path(), aggdraw.Pen("black", width=1))
+    im = draw_with(method, _sample_path(), aggdraw.Pen("black", width=1))
     assert ink_count(im) > 0
     # The top edge of the path is drawn (antialiased, so not pure black)
     assert im.getpixel((50, 10)) != WHITE
@@ -161,34 +267,8 @@ def test_path_draw(method):
 @pytest.mark.parametrize("method", DRAW_METHODS)
 def test_path_draw_without_pen(method):
     # Drawing without a pen is allowed and simply draws nothing
-    im = _draw_with(method, _sample_path())
+    im = draw_with(method, _sample_path())
     assert ink_count(im) == 0
-
-
-def _render(path):
-    """Draw a path in black on a white 100x100 surface.
-
-    Drawing black on white means any pixel that isn't WHITE is part of the
-    path. Antialiasing makes the edges gray rather than pure black, so tests
-    check for "not the background" instead of for an exact ink color.
-    """
-    draw = aggdraw.Draw("RGB", (100, 100), "white")
-    draw.path(path, aggdraw.Pen("black", 1))
-    return to_image(draw)
-
-
-def _draw_with(method, path, pen=None):
-    """Draw a path on a fresh white surface with one of the Draw methods.
-
-    ``symbol`` takes a position as well; (0, 0) draws the path where it was
-    defined, matching what the other methods do.
-    """
-    draw = aggdraw.Draw("RGB", (100, 100), "white")
-    if method == "symbol":
-        draw.symbol((0, 0), path, pen)
-    else:
-        getattr(draw, method)(path, pen)
-    return to_image(draw)
 
 
 def _sample_path():
@@ -221,3 +301,39 @@ def test_coords_does_not_leak():
 
     # 8 coordinates per call: a leak shows up as ~16000 blocks, not a handful.
     assert growth < 100, f"coords() leaked {growth} blocks over 2000 calls"
+
+
+@pytest.mark.parametrize("factory", [aggdraw.Path.from_svg, _aggdraw.Symbol])
+def test_from_svg_error_paths_do_not_leak(factory):
+    """A rejected path descriptor must release the half-built object.
+
+    The parser's error paths used to be marked "FIXME: cleanup" and returned
+    without freeing the object or its agg::path_storage. Both entry points
+    share one C helper, but they allocate from different types, so both
+    deallocation paths are worth measuring.
+
+    Do not route this through ``aggdraw.Symbol``: it emits a deprecation
+    warning, and under ``-W always`` each of the 2200 calls would record a
+    WarningMessage, adding thousands of blocks and swamping the measurement.
+    """
+    if not sys.getallocatedblocks():
+        pytest.skip("needs pymalloc to count allocated blocks")
+
+    def build():
+        # plain try/except, not pytest.raises: ExceptionInfo objects accumulate
+        # and would swamp the measurement.
+        try:
+            factory("M-")
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError")
+
+    for _ in range(200):  # let any one-time caches settle
+        build()
+
+    before = sys.getallocatedblocks()
+    for _ in range(2000):
+        build()
+    growth = sys.getallocatedblocks() - before
+
+    assert growth < 100, f"failed parse leaked {growth} blocks over 2000 calls"

--- a/aggdraw/tests/test_path.py
+++ b/aggdraw/tests/test_path.py
@@ -1,5 +1,7 @@
 """Tests for the Path class."""
 
+import sys
+
 import aggdraw
 import pytest
 
@@ -197,3 +199,25 @@ def _sample_path():
     p.rlineto(-80, 0)
     p.close()
     return p
+
+
+def test_coords_does_not_leak():
+    """coords() must release the floats it appends to the result list.
+
+    PyList_Append takes its own reference, so the one returned by
+    PyFloat_FromDouble used to leak -- one object per coordinate, per call.
+    """
+    if not sys.getallocatedblocks():
+        pytest.skip("needs pymalloc to count allocated blocks")
+
+    path = aggdraw.Path([0, 0, 10, 10, 20, 5, 30, 30])
+    for _ in range(100):  # let any one-time caches settle
+        path.coords()
+
+    before = sys.getallocatedblocks()
+    for _ in range(2000):
+        path.coords()
+    growth = sys.getallocatedblocks() - before
+
+    # 8 coordinates per call: a leak shows up as ~16000 blocks, not a handful.
+    assert growth < 100, f"coords() leaked {growth} blocks over 2000 calls"

--- a/aggdraw/tests/test_pen.py
+++ b/aggdraw/tests/test_pen.py
@@ -75,3 +75,40 @@ def test_pen_non_ascii_color():
     surf = Draw("RGB", (10, 10), "white")
     surf.rectangle((0, 0, 9, 9), Brush("café"))
     assert to_image(surf).getpixel((5, 5)) == (0, 0, 0)
+
+
+def test_pen_exposes_color_and_width():
+    """Pen.color reports the resolved color, Pen.width the pen width.
+
+    Neither was reachable from Python before the C types became real classes.
+    """
+    from aggdraw import Pen
+
+    pen = Pen("crimson", 2.5)
+    assert pen.color == (220, 20, 60, 255)
+    assert pen.width == 2.5
+
+    # a 4-tuple overrides opacity entirely
+    assert Pen((1, 2, 3, 4), opacity=200).color == (1, 2, 3, 4)
+    # an unrecognized color silently becomes black
+    assert Pen("not a color").color == (0, 0, 0, 255)
+
+
+def test_pen_is_subclassable():
+    """The C types set Py_TPFLAGS_BASETYPE and are usable as base classes.
+
+    The dispatcher inside draw_adaptor::draw checks with PyObject_TypeCheck,
+    so a subclass must still be recognized as a pen.
+    """
+    from aggdraw import Draw, _aggdraw
+    from PIL import Image
+
+    class MyPen(_aggdraw.Pen):
+        pass
+
+    assert isinstance(MyPen("red", 1), _aggdraw.Pen)
+
+    surf = _aggdraw.Draw("RGB", (20, 20), "white")
+    surf.line((0, 5.5, 20, 5.5), MyPen("red", 1))
+    im = Image.frombytes(surf.mode, surf.size, surf.tobytes())
+    assert im.getpixel((10, 5)) == (255, 0, 0)

--- a/aggdraw/tests/test_pen.py
+++ b/aggdraw/tests/test_pen.py
@@ -51,3 +51,27 @@ def test_graphics3():
     main = Image.new("RGB", (480, 1024), "white")
     d = Draw(main)
     p = Pen((90,) * 3, 0.5)
+
+
+def test_pen_type_is_readable():
+    """The C type objects must be readied at import; see issue in _aggdraw.cxx.
+
+    Before the Python 2 removal the type objects were never passed to
+    PyType_Ready, leaving ob_type NULL, so type() on one segfaulted.
+    """
+    from aggdraw import Pen
+
+    assert type(Pen("black")._pen).__name__ == "Pen"
+
+
+def test_pen_non_ascii_color():
+    """A non-ASCII color name must not crash; it falls back to black.
+
+    getcolor() used to reach strcmp() with a NULL pointer whenever
+    PyUnicode_AsASCIIString failed on the color string.
+    """
+    from aggdraw import Draw, Brush
+
+    surf = Draw("RGB", (10, 10), "white")
+    surf.rectangle((0, 0, 9, 9), Brush("café"))
+    assert to_image(surf).getpixel((5, 5)) == (0, 0, 0)

--- a/aggdraw/tests/test_symbol.py
+++ b/aggdraw/tests/test_symbol.py
@@ -1,65 +1,136 @@
-"""Tests for the Symbol class."""
+"""Tests for the deprecated Symbol class.
+
+Symbol is a deprecated subclass of Path kept for backwards compatibility; the
+SVG parser itself is tested through Path.from_svg in test_path.py. What is
+tested here is the deprecation and the subclass relationship.
+"""
+
+import aggdraw
+import pytest
+
+from aggdraw import _aggdraw
+from aggdraw.tests._helpers import WHITE, draw_with, ink_count, render
+
+DEPRECATED = "Symbol is deprecated"
+
+# A closed triangle, used wherever a Symbol and a Path.from_svg path are
+# compared: it has enough distinct edges to tell the two renderings apart.
+DESCRIPTOR = "M10,10 L90,10 L90,90 Z"
+
+# The Draw methods that accept a Path, and therefore a Symbol
+DRAW_METHODS = ["line", "polygon", "symbol", "path"]
 
 
-def test_symbol():
-    from aggdraw import Symbol
+@pytest.mark.parametrize(
+    "construct",
+    [
+        pytest.param(lambda: aggdraw.Symbol("M0,0 L10,10"), id="positional"),
+        pytest.param(lambda: aggdraw.Symbol(path="M0,0 L10,10", scale=2), id="keyword"),
+        pytest.param(lambda: aggdraw.Symbol.from_svg("M0,0 L10,10"), id="inherited-from_svg"),
+    ],
+)
+def test_symbol_construction_is_deprecated(construct):
+    """Every door into Symbol warns.
 
-    Symbol("M0,0L0,0L0,0L0,0Z")
-    Symbol("M0,0L0,0,0,0,0,0Z", 10)
-    Symbol("M0,0C0,0,0,0,0,0Z")
-    Symbol("M0,0S0,0,0,0,0,0Z")
+    The warning lives in ``__new__`` rather than ``__init__`` so that the
+    classmethod inherited from Path -- which calls ``cls.__new__`` and skips
+    ``__init__`` -- warns as well.
+    """
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        construct()
 
-    Symbol("m0,0l0,0l0,0l0,0z")
-    Symbol("m0,0l0,0,0,0,0,0z", 10)
-    Symbol("m0,0c0,0,0,0,0,0z")
-    Symbol("m0,0s0,0,0,0,0,0z")
+
+def test_symbol_is_an_equivalent_path():
+    # Symbol is a Path at both layers...
+    assert issubclass(aggdraw.Symbol, aggdraw.Path)
+    assert issubclass(_aggdraw.Symbol, _aggdraw.Path)
+
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        sym = aggdraw.Symbol(DESCRIPTOR)
+    path = aggdraw.Path.from_svg(DESCRIPTOR)
+
+    assert isinstance(sym, aggdraw.Path)
+    # ...and the wrapper holds a C Symbol, which is itself a C Path
+    assert type(sym._path).__name__ == "Symbol"
+
+    # Symbol and Path.from_svg are two spellings of the same C parser, so they
+    # must produce the same geometry and the same pixels.
+    assert sym.coords() == path.coords()
+    assert render(sym).tobytes() == render(path).tobytes()
+
+
+def test_symbol_inherits_path_methods():
+    # Symbol used to define no methods at all, so this raised AttributeError
+    # even though the underlying C object supported it.
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        sym = aggdraw.Symbol("M10,10 L90,10")
+
+    before = ink_count(render(sym))
+    sym.lineto(90, 90)
+    assert sym.coords() == [10, 10, 90, 10, 90, 90]
+    assert ink_count(render(sym)) > before
+
+
+@pytest.mark.parametrize("method", DRAW_METHODS)
+def test_draw_methods_accept_a_symbol(method):
+    """Every Draw method that takes a Path also takes a Symbol.
+
+    Draw.line and Draw.polygon guard on ``isinstance(xy, Path)``. A Symbol used
+    to fail that guard and reach the C layer as an unwrapped wrapper object,
+    raising TypeError; as a Path subclass it is now drawn like any other path.
+    """
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        sym = aggdraw.Symbol(DESCRIPTOR)
+
+    im = draw_with(method, sym, aggdraw.Pen("black", 1))
+    # The top edge of the triangle is drawn (antialiased, so not pure black)
+    assert im.getpixel((50, 10)) != WHITE
+    # A point well away from it is left alone
+    assert im.getpixel((5, 5)) == WHITE
+
+
+def test_symbol_can_be_subclassed():
+    class Marker(aggdraw.Symbol):
+        pass
+
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        marker = Marker("M0,0 L10,10")
+
+    assert type(marker) is Marker
+    assert isinstance(marker, aggdraw.Path)
+    assert marker.coords() == [0, 0, 10, 10]
+
+    # ...and so can the C type, which must allocate from the subclass
+    class CMarker(_aggdraw.Symbol):
+        pass
+
+    c_marker = CMarker("M0,0 L10,10")
+    assert type(c_marker) is CMarker
+    assert c_marker.coords() == [0, 0, 10, 10]
+
+
+def test_c_symbol_rejects_keyword_arguments():
+    # As a module-level function this was rejected for free; as a tp_new the
+    # keywords have to be turned away explicitly or scale is silently ignored.
+    with pytest.raises(TypeError, match="no keyword arguments"):
+        _aggdraw.Symbol("M0,0 L10,10", scale=2)
 
 
 def test_graphics2():
     """See issue #14."""
-    from aggdraw import Draw, Symbol, Pen
     from PIL import Image
     import numpy as np
 
-    symbol = Symbol("M400 200 L400 400")
-    pen = Pen("red")
-    image = Image.fromarray(np.zeros((800, 600, 3), dtype=np.uint8), mode="RGB")
-    canvas = Draw(image)
-    canvas.symbol((0, 0), symbol, pen)
-    canvas.flush()
-    assert np.asarray(image).sum() == 50800
+    def render_large(path):
+        image = Image.fromarray(np.zeros((800, 600, 3), dtype=np.uint8), mode="RGB")
+        canvas = aggdraw.Draw(image)
+        canvas.symbol((0, 0), path, aggdraw.Pen("red"))
+        canvas.flush()
+        return np.asarray(image).sum()
 
+    with pytest.warns(UserWarning, match=DEPRECATED):
+        symbol = aggdraw.Symbol("M400 200 L400 400")
 
-def test_invalid_symbol_does_not_leak():
-    """A rejected path descriptor must release the half-built object.
-
-    The parser's error paths used to be marked "FIXME: cleanup" and returned
-    without freeing the object or its agg::path_storage.
-    """
-    import sys
-
-    import pytest
-
-    from aggdraw import Symbol
-
-    if not sys.getallocatedblocks():
-        pytest.skip("needs pymalloc to count allocated blocks")
-
-    def build():
-        # plain try/except, not pytest.raises: ExceptionInfo objects accumulate
-        # and would swamp the measurement.
-        try:
-            Symbol("Q not a valid path")
-        except ValueError:
-            return
-        raise AssertionError("expected ValueError")
-
-    for _ in range(200):  # let any one-time caches settle
-        build()
-
-    before = sys.getallocatedblocks()
-    for _ in range(2000):
-        build()
-    growth = sys.getallocatedblocks() - before
-
-    assert growth < 100, f"failed Symbol() leaked {growth} blocks over 2000 calls"
+    # Asserted for Path.from_svg too, so the regression outlives Symbol
+    assert render_large(symbol) == 50800
+    assert render_large(aggdraw.Path.from_svg("M400 200 L400 400")) == 50800

--- a/aggdraw/tests/test_symbol.py
+++ b/aggdraw/tests/test_symbol.py
@@ -28,3 +28,38 @@ def test_graphics2():
     canvas.symbol((0, 0), symbol, pen)
     canvas.flush()
     assert np.asarray(image).sum() == 50800
+
+
+def test_invalid_symbol_does_not_leak():
+    """A rejected path descriptor must release the half-built object.
+
+    The parser's error paths used to be marked "FIXME: cleanup" and returned
+    without freeing the object or its agg::path_storage.
+    """
+    import sys
+
+    import pytest
+
+    from aggdraw import Symbol
+
+    if not sys.getallocatedblocks():
+        pytest.skip("needs pymalloc to count allocated blocks")
+
+    def build():
+        # plain try/except, not pytest.raises: ExceptionInfo objects accumulate
+        # and would swamp the measurement.
+        try:
+            Symbol("Q not a valid path")
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError")
+
+    for _ in range(200):  # let any one-time caches settle
+        build()
+
+    before = sys.getallocatedblocks()
+    for _ in range(2000):
+        build()
+    growth = sys.getallocatedblocks() - before
+
+    assert growth < 100, f"failed Symbol() leaked {growth} blocks over 2000 calls"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ environment = "MACOSX_DEPLOYMENT_TARGET=14"
 
 [tool.ruff]
 line-length = 120
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "W", "B", "UP", "S"]


### PR DESCRIPTION
This PR comes from a long time wish of mine to rewrite the C++ code (_aggdraw.cxx) to remove all Python 2 conditionals and API usage. I basically asked Claude to do the python 2 removal then I asked "this module uses factory functions to create objects, is this still done in modern times?" and Claude said no that's a 2003 common practice, not 2026.

The main things are marked in the Changelog. This PR should fix multiple memory leaks according to Claude. This PR should also be the first major step toward a Cython wrapper or maybe something more maintainable than this Python C API extension with a python wrapper. Not all class creation has been migrated to the newer APIs, but I'll have to do more reviewing to be sure what is the right path forward.

TOOD: I still need to review this completely which is why I'm marking it as a draft.